### PR TITLE
Allow parallel spritesheets by adding support for spriteName option

### DIFF
--- a/lib/templates/less.template.mustache
+++ b/lib/templates/less.template.mustache
@@ -38,9 +38,9 @@
   }
 
   .sprite{{#options.spriteName}}-{{options.spriteName}}{{/options.spriteName}}(@sprite) {
-    .sprite-image();
-    .sprite-position(@sprite);
-    .sprite-width(@sprite);
-    .sprite-height(@sprite);
+    .sprite{{#options.spriteName}}-{{options.spriteName}}{{/options.spriteName}}-image();
+    .sprite{{#options.spriteName}}-{{options.spriteName}}{{/options.spriteName}}-position(@sprite);
+    .sprite{{#options.spriteName}}-{{options.spriteName}}{{/options.spriteName}}-width(@sprite);
+    .sprite{{#options.spriteName}}-{{options.spriteName}}{{/options.spriteName}}-height(@sprite);
   }
 {{/options.functions}}

--- a/lib/templates/sass.template.mustache
+++ b/lib/templates/sass.template.mustache
@@ -34,8 +34,8 @@ ${{name}}: {{px.x}} {{px.y}} {{px.offset_x}} {{px.offset_y}} {{px.width}} {{px.h
   {{/options.spritePath}}
 
 @mixin sprite{{#options.spriteName}}-{{options.spriteName}}{{/options.spriteName}}($sprite)
-  @include sprite-image()
-  @include sprite-position($sprite)
-  @include sprite-width($sprite)
-  @include sprite-height($sprite)
+  @include sprite{{#options.spriteName}}-{{options.spriteName}}{{/options.spriteName}}-image()
+  @include sprite{{#options.spriteName}}-{{options.spriteName}}{{/options.spriteName}}-position($sprite)
+  @include sprite{{#options.spriteName}}-{{options.spriteName}}{{/options.spriteName}}-width($sprite)
+  @include sprite{{#options.spriteName}}-{{options.spriteName}}{{/options.spriteName}}-height($sprite)
 {{/options.functions}}

--- a/lib/templates/scss.template.mustache
+++ b/lib/templates/scss.template.mustache
@@ -38,9 +38,9 @@
   }
 
   @mixin sprite{{#options.spriteName}}-{{options.spriteName}}{{/options.spriteName}}($sprite) {
-    @include sprite-image();
-    @include sprite-position($sprite);
-    @include sprite-width($sprite);
-    @include sprite-height($sprite);
+    @include sprite{{#options.spriteName}}-{{options.spriteName}}{{/options.spriteName}}-image();
+    @include sprite{{#options.spriteName}}-{{options.spriteName}}{{/options.spriteName}}-position($sprite);
+    @include sprite{{#options.spriteName}}-{{options.spriteName}}{{/options.spriteName}}-width($sprite);
+    @include sprite{{#options.spriteName}}-{{options.spriteName}}{{/options.spriteName}}-height($sprite);
   }
 {{/options.functions}}

--- a/lib/templates/stylus.template.mustache
+++ b/lib/templates/stylus.template.mustache
@@ -47,9 +47,9 @@ sprite{{#options.spriteName}}{{options.spriteName}}{{/options.spriteName}}Backgr
 }
 
 sprite{{#options.spriteName}}{{options.spriteName}}{{/options.spriteName}}($sprite) {
-  background-image: url(spriteBackground());
-  background-position: spriteOffsetX($sprite) spriteOffsetY($sprite);
-  width: spriteWidth($sprite);
-  height: spriteHeight($sprite);
+  background-image: url(sprite{{#options.spriteName}}{{options.spriteName}}{{/options.spriteName}}Background());
+  background-position: sprite{{#options.spriteName}}{{options.spriteName}}{{/options.spriteName}}OffsetX($sprite) sprite{{#options.spriteName}}{{options.spriteName}}{{/options.spriteName}}OffsetY($sprite);
+  width: sprite{{#options.spriteName}}{{options.spriteName}}{{/options.spriteName}}Width($sprite);
+  height: sprite{{#options.spriteName}}{{options.spriteName}}{{/options.spriteName}}Height($sprite);
 }
 {{/options.functions}}


### PR DESCRIPTION
My goal is to be able to create multiple spritesheets for a given site and import them into the same master stylesheet (via a preprocessor). Useful when spritesheets start becoming impractically large. It didn't work with the current setup, because the mixin names plugged into the different sprite stylesheets would override each other and get tangled up. So I tried to add support for a "spriteName" property: when set, it adds to the mixin names in the output sprite stylesheet, making them specific to a certain sprite -- that way, for instance, i could have one sprite mixin for sprite-universal and another for sprite-pageone.

To do this I had to change these mustache templates and add a couple of lines to grunt-spritesmith.js -- a different pull request I'll make now.

[See https://github.com/Ensighten/grunt-spritesmith/pull/22]
