### PR TITLE
Adds size and name option to generate total sprite dimensions

### DIFF
--- a/lib/templates/less.template.mustache
+++ b/lib/templates/less.template.mustache
@@ -1,8 +1,20 @@
 {
   // Default options
-  'functions': true
+  'functions': true,
+  'size': false
 }
 
+{{#options.size}}
+{{#options.name}}
+  @{{options.name}}-total-height: {{options.size.height}}px;
+  @{{options.name}}-total-width: {{options.size.width}}px;
+{{/options.name}}
+{{^options.name}}
+  @total-height: {{options.size.height}}px;
+  @total-width: {{options.size.width}}px;
+{{/options.name}}
+
+{{/options.size}}
 {{#items}}
   @{{name}}-x: {{px.x}};
   @{{name}}-y: {{px.y}};

--- a/lib/templates/sass.template.mustache
+++ b/lib/templates/sass.template.mustache
@@ -1,8 +1,20 @@
 {
   // Default options
-  'functions': true
+  'functions': true,
+  'size': false
 }
 
+{{#options.size}}
+{{#options.name}}
+  ${{options.name}}-total-height: {{options.size.height}}px;
+  ${{options.name}}-total-width: {{options.size.width}}px;
+{{/options.name}}
+{{^options.name}}
+  $total-height: {{options.size.height}}px;
+  $total-width: {{options.size.width}}px;
+{{/options.name}}
+
+{{/options.size}}
 {{#items}}
 ${{name}}-x: {{px.x}}
 ${{name}}-y: {{px.y}}

--- a/lib/templates/scss.template.mustache
+++ b/lib/templates/scss.template.mustache
@@ -1,8 +1,20 @@
 {
   // Default options
-  'functions': true
+  'functions': true,
+  'size': false
 }
 
+{{#options.size}}
+{{#options.name}}
+  ${{options.name}}-total-height: {{options.size.height}}px;
+  ${{options.name}}-total-width: {{options.size.width}}px;
+{{/options.name}}
+{{^options.name}}
+  $total-height: {{options.size.height}}px;
+  $total-width: {{options.size.width}}px;
+{{/options.name}}
+
+{{/options.size}}
 {{#items}}
   ${{name}}-x: {{px.x}};
   ${{name}}-y: {{px.y}};

--- a/lib/templates/stylus.template.mustache
+++ b/lib/templates/stylus.template.mustache
@@ -1,8 +1,20 @@
 {
   // Default options
-  'functions': true
+  'functions': true,
+  'size': false
 }
 
+{{#options.size}}
+{{#options.name}}
+  ${{options.name}}_total_height: {{options.size.height}}px;
+  ${{options.name}}_total_width: {{options.size.width}}px;
+{{/options.name}}
+{{^options.name}}
+  $total_height: {{options.size.height}}px;
+  $total_width: {{options.size.width}}px;
+{{/options.name}}
+
+{{/options.size}}
 {{#items}}
 ${{name}}_x = {{px.x}};
 ${{name}}_y = {{px.y}};

--- a/test/json2css_content.js
+++ b/test/json2css_content.js
@@ -206,5 +206,39 @@ module.exports = {
       // console.log('SCSS', css);
       done(err);
     });
+  },
+
+  // SCSS with size
+  'processed into SCSS with size': [function () {
+    this.options = {'format': 'scss'};
+    this.options.formatOpts = {'size': {'height': '100', 'width': '50'}, 'name': 'spriteName'};
+    this.filename = 'scss.scss';
+  }, 'processed via json2css'],
+  'is valid SCSS': function (done) {
+    // Add some SCSS to our result
+    var scssStr = this.result;
+    scssStr += '\n' + [
+      '.feature {',
+      '  height: $sprite1-height;',
+      '  @include sprite-width($sprite2);',
+      '  @include sprite-image($sprite3);',
+      '}',
+      '',
+      '.feature2 {',
+      '  @include sprite($sprite2);',
+      '}'
+    ].join('\n');
+
+    // Render the SCSS, assert no errors, and valid CSS
+    var tmp = new Tempfile();
+    tmp.writeFileSync(scssStr);
+    console.log(scssStr);
+    exec('sass --scss ' + tmp.path, function (err, css, stderr) {
+      assert.strictEqual(stderr, '');
+      assert.strictEqual(err, null);
+      assert.notEqual(css, '');
+      // console.log('SCSS', css);
+      done(err);
+    });
   }
 };

--- a/test/json2css_outline.js
+++ b/test/json2css_outline.js
@@ -23,6 +23,9 @@ module.exports = {
     'processed into SCSS': {
       'matches as expected': true,
       'is valid SCSS': true
+    },
+    'processed into SCSS with size': {
+      'is valid SCSS': true
     }
   },
   'An object of image positions and dimensions keyed by names': {


### PR DESCRIPTION
Hi,

I'm trying to extend spritesmith and grunt-spritesmith to better support @2x spritesheets (for high pixel density displays). To generate @2x spritesheets you need to know the dimensions of the @1x spritesheet - you specify "background-size: @1x-spritesheet-size", which requires that information to be generated and returned by (grunt-)spritesheet.

Since json2css is at the core of spritesheet I've added the ability to pass along a size and name option to generate those required parameters. Everything looks good in my testing, and all existing tests pass.

Here's the reference to my pull request on spritesheet:

https://github.com/Ensighten/spritesmith/pull/18

Let me know what you think about adding this to json2css.
