### PR TITLE
Adding sprite-background-size and sprite-2x helpers.

### DIFF
--- a/lib/templates/less.template.mustache
+++ b/lib/templates/less.template.mustache
@@ -43,4 +43,19 @@
     .sprite-width(@sprite);
     .sprite-height(@sprite);
   }
+
+  .sprite-background-size(@sprite) {
+    @total-width: ~`"@{sprite}".split(', ')[6]`;
+    @total-height: ~`"@{sprite}".split(', ')[7]`;
+    background-size: @total-width @total-height;
+  }
+
+  {{! DEV: To use this, you must generate two identical spritesheets. One with each image at 2x resolution and one with each image at 1x resolution }}
+  .sprite-2x(@sprite2x, @sprite1x) {
+    .sprite(@sprite2x);
+    .sprite-position(@sprite1x);
+    .sprite-width(@sprite1x);
+    .sprite-height(@sprite1x);
+    .sprite-background-size(@sprite1x);
+  }
 {{/options.functions}}

--- a/lib/templates/sass.template.mustache
+++ b/lib/templates/sass.template.mustache
@@ -31,9 +31,21 @@ ${{name}}: {{px.x}} {{px.y}} {{px.offset_x}} {{px.offset_y}} {{px.width}} {{px.h
 @mixin sprite-image($sprite)
   background-image: url(nth($sprite, 9))
 
+@mixin sprite-background-size($sprite)
+  $total-width: nth($sprite, 7)
+  $total-height: nth($sprite, 8)
+  background-size: $total-width $total-height
+
 @mixin sprite($sprite)
   @include sprite-image($sprite)
   @include sprite-position($sprite)
   @include sprite-width($sprite)
   @include sprite-height($sprite)
+
+@mixin sprite-2x($sprite2x, $sprite1x)
+  @include sprite($sprite2x)
+  @include sprite-position($sprite1x)
+  @include sprite-width($sprite1x)
+  @include sprite-height($sprite1x)
+  @include sprite-background-size($sprite1x)
 {{/options.functions}}

--- a/lib/templates/scss.template.mustache
+++ b/lib/templates/scss.template.mustache
@@ -35,10 +35,22 @@
     background-image: url(nth($sprite, 9));
   }
 
+  @mixin sprite-background-size($sprite)
+    $total-width: nth($sprite, 7)
+    $total-height: nth($sprite, 8)
+    background-size: $total-width $total-height
+
   @mixin sprite($sprite) {
     @include sprite-image($sprite);
     @include sprite-position($sprite);
     @include sprite-width($sprite);
     @include sprite-height($sprite);
   }
+
+  @mixin sprite-2x($sprite2x, $sprite1x)
+    @include sprite($sprite2x)
+    @include sprite-position($sprite1x)
+    @include sprite-width($sprite1x)
+    @include sprite-height($sprite1x)
+    @include sprite-background-size($sprite1x)
 {{/options.functions}}

--- a/lib/templates/stylus.template.mustache
+++ b/lib/templates/stylus.template.mustache
@@ -33,10 +33,22 @@ spriteImage($sprite) {
   background-image: url($sprite[8]);
 }
 
+spriteBackgroundSize($sprite) {
+  background-size: $sprite[6] $sprite[7];
+}
+
 sprite($sprite) {
   spriteImage($sprite)
   spritePosition($sprite)
   spriteWidth($sprite)
   spriteHeight($sprite)
+}
+
+sprite2x($sprite2x, $sprite1x) {
+  sprite($sprite2x)
+  sprite-position($sprite1x)
+  sprite-width($sprite1x)
+  sprite-height($sprite1x)
+  sprite-background-size($sprite1x)
 }
 {{/options.functions}}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "email": "todd@twolfson.com",
     "url": "http://twolfson.com/"
   },
+  "contributors": ["Alex Bain <alex@alexba.in>"],
   "repository": {
     "type": "git",
     "url": "git://github.com/twolfson/json2css.git"


### PR DESCRIPTION
This pull request creates two additional helpers that makes it much easier to build retina spritesheets with the grunt-spritesmith, spritesmith, json2css stack.

`sprite-background-size`: Adds the ability to set a background-size property to the total-width, total-height properties of the sprite.
`sprite-2x`: This helper is a convenience method for easily creating @2x sprites. It takes two arguments - `@sprite2x` and `@sprite1x` and puts together the right blend of CSS to render the sprite correctly on a high pixel density display.

To properly do @2x sprites you'll still need to define two distinct spritesheets. Example:

```
homepage-sprite-src/
    logo.png
    footer.png
    icon-email.png

homepage-sprite-2x-src/
    logo-2x.png
    footer-2x.png
    icon-email-2x.png
```

grunt-spritesmith would have to know about both of these spritesheets, and you'd have to include both in your LESS/SCSS/Stylus/etc.

After including the generated output, you can do something like this in the CSS:

```
.logo {
    .sprite(@logo);
}

@media only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-device-pixel-ratio: 1.5) {
    .logo {
        .sprite-2x(@logo-2x, @logo);
    }
}
```

Please take a look at this and let me know what you think!

Thanks.
