### PR TITLE
features(retnia): Add retnia calculations.

### DIFF
--- a/lib/json2css.js
+++ b/lib/json2css.js
@@ -38,6 +38,7 @@ function json2css(input, options) {
   var inputObj = new Input(input);
   inputObj.ensureOffsetAndPx();
   inputObj.escapeImages();
+  inputObj.supportRetnia();
 
   // Process the input via the template
   input = inputObj['export']();
@@ -51,6 +52,31 @@ function Input(input) {
   this.input = input;
 }
 Input.prototype = {
+  
+  // Helper to support Retnia in templates 
+  // by generating half values, so we can adjust element width and bg size. 
+  'supportRetnia' : function() {
+    this.input.forEach(function (item) {
+      
+      // retnia namespace
+      var retnia = {};
+      item.retnia = retnia;
+      
+      // calculations
+      item.retnia.half_offset_x = -(item.x / 2);
+      item.retnia.half_offset_y = -(item.y / 2);
+      item.retnia.half_width = item.width / 2;
+      item.retnia.half_height = item.height / 2;
+      item.retnia.half_total_width = item.total_width / 2;
+      item.retnia.half_total_height = item.total_height / 2;
+
+      // ensure prefix
+      ['half_width', 'half_height', 'half_total_width', 'half_total_height', 'half_offset_x', 'half_offset_y'].forEach(function (key) {
+        item.retnia[key] = item.retnia[key] + 'px';
+      });
+
+    });
+  },
   // Helper function to ensure offset values exist as well as values with pixels in the name
   'ensureOffsetAndPx': function () {
     // Iterate over the input and ensure there are offset values as well as pixel items


### PR DESCRIPTION
This PR adds calculations needed to write a mustache template that supports retnia. 

I came across the need for this in a recent project. I used a template like the one below, but since mustache templates don't support JS functions, I needed to do the calcs elsewhere. 

Example Template: 

```
{{#items}}
.retnia_sprite_{{name}} {
  background-image: url('{{{escaped_image}}}');
  background-position: {{retnia.half_offset_x}} {{retnia.half_offset_y}};
  width: {{retnia.half_width}};
  height: {{retnia.half_height}};
  background-size: {{retnia.half_total_width}} {{retnia.half_total_height}};
}
{{/items}}
```

@note It could be worth building this out a bit more to add robust retnia support to spritesmith. ie: adding documentation, example templates, etc. 
