### PR TITLE
Made changes to be compatible with libsass

### DIFF
--- a/lib/templates/scss.template.mustache
+++ b/lib/templates/scss.template.mustache
@@ -32,8 +32,8 @@
   }
 
   @mixin sprite-image($sprite) {
-    $sprite-image-url: nth($sprite, 9);
-    background-image: url($sprite-image-url);
+    $sprite-image: nth($sprite, 9);
+    background-image: url("#{$sprite-image}");
   }
 
   @mixin sprite($sprite) {


### PR DESCRIPTION
Libsass has issues with this statement inline i.e. "error: non-terminal statement or declaration must end with ';'"

Splitting the line into two fixes the issue, without breaking the ruby scss standard
