### PR TITLE
[RFC] Added scssMap template for sass 3.3+

### DIFF
--- a/lib/json2css.js
+++ b/lib/json2css.js
@@ -142,5 +142,8 @@ addMustacheTemplate('sass', sassMustache);
 var scssMustache = fs.readFileSync(templatesDir + '/scss.template.mustache', 'utf8');
 addMustacheTemplate('scss', scssMustache);
 
+var scssMapsMustache = fs.readFileSync(templatesDir + '/scss_maps.template.mustache', 'utf8');
+addMustacheTemplate('scss_maps', scssMapsMustache);
+
 // Expose json2css
 module.exports = json2css;

--- a/lib/templates/scss_maps.template.mustache
+++ b/lib/templates/scss_maps.template.mustache
@@ -1,0 +1,47 @@
+{
+  // Default options
+  'functions': true
+}
+
+$sprites: (
+  {{#items}}
+  {{name}}: (
+    x: {{px.x}},
+    y: {{px.y}},
+    offset_x: {{px.offset_x}},
+    offset_y: {{px.offset_y}},
+    width: {{px.width}},
+    height: {{px.height}},
+    total_width: {{px.total_width}},
+    total_height: {{px.total_height}},
+    image: '{{{escaped_image}}}'
+  ),
+  {{/items}}
+);
+
+@function sprite($sprite, $attribute) {
+  @return map-get(map-get($sprites, $sprite), $attribute),
+}
+
+@mixin sprite-width($sprite) {
+  width: sprite($sprite, 'width');
+}
+
+@mixin sprite-height($sprite) {
+  width: sprite($sprite, 'height');
+}
+
+@mixin sprite-position($sprite) {
+  background-position: sprite($sprite, 'offset_x') sprite($sprite, 'offset_y');
+}
+
+@mixin sprite-image($sprite) {
+  background-image: url(sprite($sprite, 'image'));
+}
+
+@mixin sprite($sprite) {
+  @include sprite-image($sprite);
+  @include sprite-position($sprite);
+  @include sprite-width($sprite);
+  @include sprite-height($sprite);
+}

--- a/test/expected_files/scss_maps.scss
+++ b/test/expected_files/scss_maps.scss
@@ -1,0 +1,62 @@
+$sprites: (
+  sprite1: (
+    x: 0px,
+    y: 0px,
+    offset_x: 0px,
+    offset_y: 0px,
+    width: 10px,
+    height: 20px,
+    total_width: 80px,
+    total_height: 100px,
+    image: 'nested/dir/spritesheet.png'
+  ),
+  sprite2: (
+    x: 10px,
+    y: 20px,
+    offset_x: -10px,
+    offset_y: -20px,
+    width: 20px,
+    height: 30px,
+    total_width: 80px,
+    total_height: 100px,
+    image: 'nested/dir/spritesheet.png'
+  ),
+  sprite3: (
+    x: 30px,
+    y: 50px,
+    offset_x: -30px,
+    offset_y: -50px,
+    width: 50px,
+    height: 50px,
+    total_width: 80px,
+    total_height: 100px,
+    image: 'nested/dir/%28%20%27%22%29/spritesheet.png'
+  ),
+);
+
+@function sprite($sprite, $attribute) {
+  @return map-get(map-get($sprites, $sprite), $attribute),
+}
+
+@mixin sprite-width($sprite) {
+  width: sprite($sprite, 'width');
+}
+
+@mixin sprite-height($sprite) {
+  width: sprite($sprite, 'height');
+}
+
+@mixin sprite-position($sprite) {
+  background-position: sprite($sprite, 'offset_x') sprite($sprite, 'offset_y');
+}
+
+@mixin sprite-image($sprite) {
+  background-image: url(sprite($sprite, 'image'));
+}
+
+@mixin sprite($sprite) {
+  @include sprite-image($sprite);
+  @include sprite-position($sprite);
+  @include sprite-width($sprite);
+  @include sprite-height($sprite);
+}

--- a/test/json2css_scss_maps_test.js
+++ b/test/json2css_scss_maps_test.js
@@ -1,0 +1,62 @@
+var assert = require('assert'),
+    exec = require('child_process').exec,
+    Tempfile = require('temporary/lib/file'),
+    utils = require('./utils');
+
+describe('An array of image positions, dimensions, and names', function () {
+  utils.setupImages();
+
+  describe('processed by `json2css` into SCSS (Maps)', function () {
+    before(function () {
+      this.options = {'format': 'scss_maps'};
+      this.filename = 'scss_maps.scss';
+    });
+    utils.runJson2Css();
+
+    before(function writeScssToFile () {
+      // Add some SCSS to our result
+      var scssStr = this.result;
+      scssStr += '\n' + [
+        '.feature {',
+        '  height: sprite("sprite1", "height");',
+        '  @include sprite-width("sprite2");',
+        '  @include sprite-image("sprite3");',
+        '}',
+        '',
+        '.feature2 {',
+        '  @include sprite("sprite2");',
+        '}'
+      ].join('\n');
+
+      // Save the SCSS to a file for processing
+      var tmp = new Tempfile();
+      tmp.writeFileSync(scssStr);
+      this.tmp = tmp;
+    });
+    after(function () {
+      this.tmp.unlinkSync();
+    });
+
+    utils.assertMatchesAsExpected();
+
+    describe('processed by `sass --scss` (ruby) into CSS', function () {
+      // Process the SCSS
+      before(function (done) {
+        var that = this;
+        exec('sass --scss ' + this.tmp.path, function (err, css, stderr) {
+          // Assert no errors during conversion
+          assert.strictEqual(stderr, '');
+          assert.strictEqual(err, null);
+          assert.notEqual(css, '');
+
+          // Save CSS for later and callback
+          that.css = css;
+          done(err);
+        });
+      });
+
+      // Assert agains the generated CSS
+      utils.assertValidCss();
+    });
+  });
+});


### PR DESCRIPTION
I quickly threw this scss template for sass 3.3+ together that takes advantage of the new sass maps. This still requires a bit more testing in production. What do you think is this something that could be added or even replace the existing scss template?

Example Output:

``` scss
@function sprite($sprite, $attribute) {
    @return map-get(map-get($sprites, $sprite), $attribute),
}

$sprites: (
    remove: (
        x: 0px,
        y: 0px,
        offset_x: 0px,
        offset_y: 0px,
        width: 10px,
        height: 11px,
        total_width: 10px,
        total_height: 233px,
        image: 'icon-sprite.png'
    ),
    remove_active: (
        x: 0px,
        y: 111px,
        offset_x: 0px,
        offset_y: -111px,
        width: 10px,
        height: 11px,
        total_width: 10px,
        total_height: 233px,
        image: 'icon-sprite.png'
    ),
    remove_hover: (
        x: 0px,
        y: 222px,
        offset_x: 0px,
        offset_y: -222px,
        width: 10px,
        height: 11px,
        total_width: 10px,
        total_height: 233px,
        image: 'icon-sprite.png'
    ),
);

@mixin spriteWidth($sprite) {
  width: sprite($sprite, 'width');
}

@mixin spriteHeight($sprite) {
  width: sprite($sprite, 'height');
}

@mixin spritePosition($sprite) {
  background-position: sprite($sprite, 'offset_x') sprite($sprite, 'offset_y');
}

@mixin spriteImage($sprite) {
  background-image: url(sprite($sprite, 'image'));
}

@mixin sprite($sprite) {
  @include spriteImage($sprite);
  @include spritePosition($sprite);
  @include spriteWidth($sprite);
  @include spriteHeight($sprite);
}
```

Example Usage:

List all sprites as icons:

``` scss
@each $sprite, $attributes in $sprites {
    .Icon--#{$sprite} {
        @include sprite($sprite);
    }
}
```

Create single sprite:

``` scss
.Icon--remove {
    @include sprite('remove');
}
```
