### PR TITLE
allow config of sass-map name to support more than one sprite with maps

### DIFF
--- a/lib/templates/scss_maps.template.mustache
+++ b/lib/templates/scss_maps.template.mustache
@@ -1,9 +1,10 @@
 {
   // Default options
-  'functions': true
+  'functions': true,
+  'mapName': 'sprites'
 }
 
-$sprites: (
+${{options.mapName}}: (
   {{#items}}
   {{name}}: (
     x: {{px.x}},
@@ -19,24 +20,25 @@ $sprites: (
   {{/items}}
 );
 
-@function sprite($sprite, $attribute) {
-  @return map-get(map-get($sprites, $sprite), $attribute),
+{{#options.functions}}
+@function sprite_{{options.mapName}}($sprite, $attribute) {
+  @return map-get(map-get(${{options.mapName}}, $sprite), $attribute),
 }
 
 @mixin sprite-width($sprite) {
-  width: sprite($sprite, 'width');
+  width: sprite_{{options.mapName}}($sprite, 'width');
 }
 
 @mixin sprite-height($sprite) {
-  height: sprite($sprite, 'height');
+  height: sprite_{{options.mapName}}($sprite, 'height');
 }
 
 @mixin sprite-position($sprite) {
-  background-position: sprite($sprite, 'offset_x') sprite($sprite, 'offset_y');
+  background-position: sprite_{{options.mapName}}($sprite, 'offset_x') sprite_{{options.mapName}}($sprite, 'offset_y');
 }
 
 @mixin sprite-image($sprite) {
-  background-image: url(sprite($sprite, 'image'));
+  background-image: url(sprite_{{options.mapName}}($sprite, 'image'));
 }
 
 @mixin sprite($sprite) {
@@ -45,3 +47,4 @@ $sprites: (
   @include sprite-width($sprite);
   @include sprite-height($sprite);
 }
+{{/options.functions}}

--- a/test/expected_files/scss_maps.scss
+++ b/test/expected_files/scss_maps.scss
@@ -34,24 +34,24 @@ $sprites: (
   ),
 );
 
-@function sprite($sprite, $attribute) {
+@function sprite_sprites($sprite, $attribute) {
   @return map-get(map-get($sprites, $sprite), $attribute),
 }
 
 @mixin sprite-width($sprite) {
-  width: sprite($sprite, 'width');
+  width: sprite_sprites($sprite, 'width');
 }
 
 @mixin sprite-height($sprite) {
-  height: sprite($sprite, 'height');
+  height: sprite_sprites($sprite, 'height');
 }
 
 @mixin sprite-position($sprite) {
-  background-position: sprite($sprite, 'offset_x') sprite($sprite, 'offset_y');
+  background-position: sprite_sprites($sprite, 'offset_x') sprite_sprites($sprite, 'offset_y');
 }
 
 @mixin sprite-image($sprite) {
-  background-image: url(sprite($sprite, 'image'));
+  background-image: url(sprite_sprites($sprite, 'image'));
 }
 
 @mixin sprite($sprite) {

--- a/test/json2css_scss_maps_test.js
+++ b/test/json2css_scss_maps_test.js
@@ -18,7 +18,7 @@ describe('An array of image positions, dimensions, and names', function () {
       var scssStr = this.result;
       scssStr += '\n' + [
         '.feature {',
-        '  height: sprite("sprite1", "height");',
+        '  height: sprite_sprites("sprite1", "height");',
         '  @include sprite-width("sprite2");',
         '  @include sprite-image("sprite3");',
         '}',


### PR DESCRIPTION
this allows the configuration of the sass-map name in cssOpts of grunt-spritesmith. This is needed if you want to generate more than one sprite with the sass-maps template.
The sass-maps format is needed if you want to be able to generate the names of the single images in f.e. a @for loop as you cannot use generated variable names in sass.

tests are changed to cover the default configuration.

Users who make use of this config setting would then probably set functions: false and write their own mixins to take the different map names into account.

This PR doesn't break bc for users who used the generated sprite mixin. Users who relied on the sprite function will see a bc break though. This is a thing that could be avoided by checking if the new option is not defined and then keep the template as it was before. This will lead to an slightly uglier template though. Let me know what you think.
