### PR TITLE
Changed separated background-* declarations to background shortcut

### DIFF
--- a/lib/templates/css.template.mustache
+++ b/lib/templates/css.template.mustache
@@ -7,8 +7,7 @@ Icon classes can be used entirely standalone. They are named after their origina
 */
 {{#items}}
 {{class}} {
-  background-image: url({{{escaped_image}}});
-  background-position: {{px.offset_x}} {{px.offset_y}};
+  background: url({{{escaped_image}}}) no-repeat {{px.offset_x}} {{px.offset_y}};
   width: {{px.width}};
   height: {{px.height}};
 }

--- a/lib/templates/less.template.mustache
+++ b/lib/templates/less.template.mustache
@@ -58,8 +58,10 @@ The provided classes are intended to be used with the array-like variables
 }
 
 .sprite(@sprite) {
-  .sprite-image(@sprite);
-  .sprite-position(@sprite);
+  @sprite-image: ~`"@{sprite}".split(', ')[8].slice(1, -2)`;
+  @sprite-offset-x: ~`"@{sprite}".split(', ')[2]`;
+  @sprite-offset-y: ~`"@{sprite}".split(', ')[3]`;
+  background: url(@sprite-image) no-repeat @sprite-offset-x  @sprite-offset-y;
   .sprite-width(@sprite);
   .sprite-height(@sprite);
 }

--- a/lib/templates/sass.template.mustache
+++ b/lib/templates/sass.template.mustache
@@ -51,8 +51,10 @@ ${{name}}: {{px.x}} {{px.y}} {{px.offset_x}} {{px.offset_y}} {{px.width}} {{px.h
   background-image: url(#{$sprite-image})
 
 @mixin sprite($sprite)
-  @include sprite-image($sprite)
-  @include sprite-position($sprite)
+  $sprite-image: nth($sprite, 9)
+  $sprite-offset-x: nth($sprite, 3)
+  $sprite-offset-y: nth($sprite, 4)
+  background: url(#{$sprite-image} no-repeat $sprite-offset-x  $sprite-offset-y  
   @include sprite-width($sprite)
   @include sprite-height($sprite)
 {{/options.functions}}

--- a/lib/templates/scss.template.mustache
+++ b/lib/templates/scss.template.mustache
@@ -58,8 +58,10 @@ The provided mixins are intended to be used with the array-like variables
 }
 
 @mixin sprite($sprite) {
-  @include sprite-image($sprite);
-  @include sprite-position($sprite);
+  $sprite-image: nth($sprite, 9);
+  $sprite-offset-x: nth($sprite, 3);
+  $sprite-offset-y: nth($sprite, 4);
+  background: url(#{$sprite-image}) no-repeat $sprite-offset-x  $sprite-offset-y;
   @include sprite-width($sprite);
   @include sprite-height($sprite);
 }

--- a/lib/templates/scss_maps.template.mustache
+++ b/lib/templates/scss_maps.template.mustache
@@ -53,8 +53,7 @@ The provided mixins are intended to be used with variables directly
 }
 
 @mixin sprite($sprite) {
-  @include sprite-image($sprite);
-  @include sprite-position($sprite);
+  background: url(map-get($sprite, 'image')) no-repeat map-get($sprite, 'offset_x') map-get($sprite, 'offset_y');
   @include sprite-width($sprite);
   @include sprite-height($sprite);
 }

--- a/lib/templates/stylus.template.mustache
+++ b/lib/templates/stylus.template.mustache
@@ -55,8 +55,7 @@ spriteImage($sprite) {
 }
 
 sprite($sprite) {
-  spriteImage($sprite)
-  spritePosition($sprite)
+  background: url($sprite[8]) no-repeat $sprite[2] $sprite[3];
   spriteWidth($sprite)
   spriteHeight($sprite)
 }


### PR DESCRIPTION
Hi Twolfson,

the title of this comment says it all: I changed the sprite mixin in all style templates to output the background shortcut instead of background-image, background-position to save a couple lines of code. I chose to fork your repo, because I use it extensively in a bunch of projects via grunt-spritesmith, but as I said before I wanted to have the shortcut instead of separate declarations.

Maybe you want to merge my changes with your original json2css repo.

Best regards!
webastronaut