### PR TITLE
Update deps / Use SVG badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# json2css [![Build status](https://travis-ci.org/twolfson/json2css.png?branch=master)](https://travis-ci.org/twolfson/json2css)
+# json2css [![Build status](https://travis-ci.org/twolfson/json2css.svg?branch=master)](https://travis-ci.org/twolfson/json2css)
 
 Convert JSON into pre-processor ready CSS.
 


### PR DESCRIPTION
-  <del>I updated `dependencies` and `devDependencies`.</del>
- <del>I updated the option of the [`jshint` task](https://github.com/gruntjs/grunt-contrib-jshint).</del>
  - <del>Now we don't need to specify the global variables of [Mocha](http://visionmedia.github.io/mocha/) explicitly, because [JSHnit supports the mocha option](https://github.com/jshint/jshint/pull/1597) from v2.5.0</del>.
- I changed the image format of the build status badge from PNG to SVG. SVG badges look beautiful on retina display.
