### PR TITLE
Use single-line comments for SASS/SCSS templates

### DIFF
--- a/lib/templates/sass.template.mustache
+++ b/lib/templates/sass.template.mustache
@@ -3,15 +3,15 @@
   'functions': true
 }
 
-/*
-  SASS variables are information about icon's compiled state, stored under its original file name
-
-  .icon-home
-    width: $icon-home-width
-
-  The large array-like variables contain all information about a single icon
-  $icon-home: x y offset_x offset_y width height total_width total_height image_path
-  */
+//
+// SASS variables are information about icon's compiled state, stored under its original file name
+//
+// .icon-home
+//   width: $icon-home-width
+//
+// The large array-like variables contain all information about a single icon
+// $icon-home: x y offset_x offset_y width height total_width total_height image_path
+//
 {{#items}}
 ${{name}}-x: {{px.x}}
 ${{name}}-y: {{px.y}}
@@ -26,15 +26,15 @@ ${{name}}: {{px.x}} {{px.y}} {{px.offset_x}} {{px.offset_y}} {{px.width}} {{px.h
 {{/items}}
 
 {{#options.functions}}
-/*
-  The provided mixins are intended to be used with the array-like variables
-
-  .icon-home
-    @include sprite-width($icon-home)
-
-  .icon-email
-    @include sprite($icon-email)
-  */
+//
+// The provided mixins are intended to be used with the array-like variables
+//
+// .icon-home
+//   @include sprite-width($icon-home)
+//
+// .icon-email
+//   @include sprite($icon-email)
+//
 @mixin sprite-width($sprite)
   width: nth($sprite, 5)
 

--- a/lib/templates/scss.template.mustache
+++ b/lib/templates/scss.template.mustache
@@ -3,16 +3,16 @@
   'functions': true
 }
 
-/*
-SCSS variables are information about icon's compiled state, stored under its original file name
-
-.icon-home {
-  width: $icon-home-width;
-}
-
-The large array-like variables contain all information about a single icon
-$icon-home: x y offset_x offset_y width height total_width total_height image_path;
-*/
+//
+// SCSS variables are information about icon's compiled state, stored under its original file name
+//
+// .icon-home {
+//   width: $icon-home-width;
+// }
+//
+// The large array-like variables contain all information about a single icon
+// $icon-home: x y offset_x offset_y width height total_width total_height image_path;
+//
 {{#items}}
 ${{name}}-x: {{px.x}};
 ${{name}}-y: {{px.y}};
@@ -27,17 +27,17 @@ ${{name}}: {{px.x}} {{px.y}} {{px.offset_x}} {{px.offset_y}} {{px.width}} {{px.h
 {{/items}}
 
 {{#options.functions}}
-/*
-The provided mixins are intended to be used with the array-like variables
-
-.icon-home {
-  @include sprite-width($icon-home);
-}
-
-.icon-email {
-  @include sprite($icon-email);
-}
-*/
+//
+// The provided mixins are intended to be used with the array-like variables
+//
+// .icon-home {
+//   @include sprite-width($icon-home);
+// }
+//
+// .icon-email {
+//   @include sprite($icon-email);
+// }
+//
 @mixin sprite-width($sprite) {
   width: nth($sprite, 5);
 }

--- a/lib/templates/scss_maps.template.mustache
+++ b/lib/templates/scss_maps.template.mustache
@@ -3,13 +3,13 @@
   'functions': true
 }
 
-/*
-SCSS variables are information about icon's compiled state, stored under its original file name
-
-.icon-home {
-  width: map-get($icon-home, 'width');
-}
-*/
+//
+// SCSS variables are information about icon's compiled state, stored under its original file name
+//
+// .icon-home {
+//   width: map-get($icon-home, 'width');
+// }
+//
 {{#items}}
 ${{name}}: (
   x: {{px.x}},
@@ -25,17 +25,17 @@ ${{name}}: (
 {{/items}}
 
 {{#options.functions}}
-/*
-The provided mixins are intended to be used with variables directly
-
-.icon-home {
-  @include sprite-width($icon-home);
-}
-
-.icon-email {
-  @include sprite($icon-email);
-}
-*/
+//
+// The provided mixins are intended to be used with variables directly
+//
+// .icon-home {
+//   @include sprite-width($icon-home);
+// }
+//
+// .icon-email {
+//   @include sprite($icon-email);
+// }
+//
 @mixin sprite-width($sprite) {
   width: map-get($sprite, 'width');
 }

--- a/test/expected_files/sass.sass
+++ b/test/expected_files/sass.sass
@@ -1,12 +1,12 @@
-/*
-  SASS variables are information about icon's compiled state, stored under its original file name
-
-  .icon-home
-    width: $icon-home-width
-
-  The large array-like variables contain all information about a single icon
-  $icon-home: x y offset_x offset_y width height total_width total_height image_path
-  */
+//
+// SASS variables are information about icon's compiled state, stored under its original file name
+//
+// .icon-home
+//   width: $icon-home-width
+//
+// The large array-like variables contain all information about a single icon
+// $icon-home: x y offset_x offset_y width height total_width total_height image_path
+//
 $sprite1-x: 0px
 $sprite1-y: 0px
 $sprite1-offset-x: 0px
@@ -38,15 +38,15 @@ $sprite3-total-height: 100px
 $sprite3-image: 'nested/dir/%28%20%27%22%29/spritesheet.png'
 $sprite3: 30px 50px -30px -50px 50px 50px 80px 100px 'nested/dir/%28%20%27%22%29/spritesheet.png'
 
-/*
-  The provided mixins are intended to be used with the array-like variables
-
-  .icon-home
-    @include sprite-width($icon-home)
-
-  .icon-email
-    @include sprite($icon-email)
-  */
+//
+// The provided mixins are intended to be used with the array-like variables
+//
+// .icon-home
+//   @include sprite-width($icon-home)
+//
+// .icon-email
+//   @include sprite($icon-email)
+//
 @mixin sprite-width($sprite)
   width: nth($sprite, 5)
 

--- a/test/expected_files/scss.scss
+++ b/test/expected_files/scss.scss
@@ -1,13 +1,13 @@
-/*
-SCSS variables are information about icon's compiled state, stored under its original file name
-
-.icon-home {
-  width: $icon-home-width;
-}
-
-The large array-like variables contain all information about a single icon
-$icon-home: x y offset_x offset_y width height total_width total_height image_path;
-*/
+//
+// SCSS variables are information about icon's compiled state, stored under its original file name
+//
+// .icon-home {
+//   width: $icon-home-width;
+// }
+//
+// The large array-like variables contain all information about a single icon
+// $icon-home: x y offset_x offset_y width height total_width total_height image_path;
+//
 $sprite1-x: 0px;
 $sprite1-y: 0px;
 $sprite1-offset-x: 0px;
@@ -39,17 +39,17 @@ $sprite3-total-height: 100px;
 $sprite3-image: 'nested/dir/%28%20%27%22%29/spritesheet.png';
 $sprite3: 30px 50px -30px -50px 50px 50px 80px 100px 'nested/dir/%28%20%27%22%29/spritesheet.png';
 
-/*
-The provided mixins are intended to be used with the array-like variables
-
-.icon-home {
-  @include sprite-width($icon-home);
-}
-
-.icon-email {
-  @include sprite($icon-email);
-}
-*/
+//
+// The provided mixins are intended to be used with the array-like variables
+//
+// .icon-home {
+//   @include sprite-width($icon-home);
+// }
+//
+// .icon-email {
+//   @include sprite($icon-email);
+// }
+//
 @mixin sprite-width($sprite) {
   width: nth($sprite, 5);
 }

--- a/test/expected_files/scss_maps.scss
+++ b/test/expected_files/scss_maps.scss
@@ -1,10 +1,10 @@
-/*
-SCSS variables are information about icon's compiled state, stored under its original file name
-
-.icon-home {
-  width: map-get($icon-home, 'width');
-}
-*/
+//
+// SCSS variables are information about icon's compiled state, stored under its original file name
+//
+// .icon-home {
+//   width: map-get($icon-home, 'width');
+// }
+//
 $sprite1: (
   x: 0px,
   y: 0px,
@@ -39,17 +39,17 @@ $sprite3: (
   image: 'nested/dir/%28%20%27%22%29/spritesheet.png'
 );
 
-/*
-The provided mixins are intended to be used with variables directly
-
-.icon-home {
-  @include sprite-width($icon-home);
-}
-
-.icon-email {
-  @include sprite($icon-email);
-}
-*/
+//
+// The provided mixins are intended to be used with variables directly
+//
+// .icon-home {
+//   @include sprite-width($icon-home);
+// }
+//
+// .icon-email {
+//   @include sprite($icon-email);
+// }
+//
 @mixin sprite-width($sprite) {
   width: map-get($sprite, 'width');
 }


### PR DESCRIPTION
According to this documentation: http://sass-lang.com/documentation/file.SASS_REFERENCE.html#comments

If we use single-comments, the comments are removed at the compilation.