### PR TITLE
Add spritesheet.px for templating

### DIFF
--- a/lib/spritesheet-templates.js
+++ b/lib/spritesheet-templates.js
@@ -44,7 +44,16 @@ function templater(params, options) {
   var items = JSON.parse(JSON.stringify(params.items));
   var spritesheet = JSON.parse(JSON.stringify(params.spritesheet));
   spritesheet.name = options.spritesheetName || 'spritesheet';
+  
+  // Create a px namespace
+  var spritesheetPx = {};
+  spritesheet.px = spritesheetPx;
 
+  // For each of the height, width, add a px after that
+  ['height', 'width'].forEach(function (key) {
+    spritesheet.px[key] = spritesheet[key] + 'px';
+  });
+  
   // Add on extra data to spritesheet and each item
   templater.escapeImage(spritesheet);
   templater.ensureTemplateVariables(spritesheet);


### PR DESCRIPTION
Items have .px string values for all pixel measurements. This adds the same to spritesheet.

Note this is just a hack at the moment to demonstrate. Happy to clean it up if needed.