### PR TITLE
Added support for the JSON format used by PIXI.js and TexturePacker

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Output CSS variables as an array of objects.
 #### `json_texture`
 Output CSS variables as an object in format similar to that of [TexturePacker](https://www.codeandweb.com/texturepacker). Useful for game frameworks, such as [Phaser](http://phaser.io/), [Pixi.js](http://www.pixijs.com/) and others.
 
-This template will not use the `name` field of the sprite object. Instead, it will use the filename of the image file with the file extension retained. If you actually do want to change the key, you can explicity set the `frame_name` field of the sprite obect. If you use grunt-spritesmith, this could be done like this:
+This template will not use the `name` field of the sprite object. Instead, it will use the filename of the image file with the file extension retained. If you actually do want to change the key, you can explicity set the `frame_name` field of the sprite obect. If you use grunt-spritesmith, it can be done like this:
 
 ```js
 cssVarMap: function (sprite) {

--- a/README.md
+++ b/README.md
@@ -223,6 +223,43 @@ Output CSS variables as an array of objects.
         // ...
 ```
 
+#### `json_texture`
+Output CSS variables as an object in format similar to that of [TexturePacker](https://www.codeandweb.com/texturepacker). Useful for game frameworks, such as [Phaser](http://phaser.io/), [Pixi.js](http://www.pixijs.com/) and others.
+
+This template will not use the `name` field of the sprite object. Instead, it will use the filename of the image file with the file extension retained. If you actually do want to change the key, you can explicity set the `frame_name` field of the sprite obect. If you use grunt-spritesmith, this could be done like this:
+
+```js
+cssVarMap: function (sprite) {
+  sprite.frame_name = 'sprite_' + path.basename(sprite.source_image);
+}
+```
+
+**Example:**
+```js
+{
+    "frames": {
+        "mysprite.png": {
+            "frame": {
+                "x": 10,
+                "y": 20,
+                "w": 20,
+                "h": 30
+            }
+        },
+        // ...
+    },
+    "meta": {
+        "app": "spritesheet-templates",
+        "version": "9.5.0",
+        "image": "nested/dir/spritesheet.png",
+        "scale": 1,
+        "size": {
+            "w": 80,
+            "h": 100
+        }
+    }
+}
+```
 #### `less`
 Output CSS variables as [LESS][] variables.
 

--- a/lib/spritesheet-templates.js
+++ b/lib/spritesheet-templates.js
@@ -315,7 +315,7 @@ templater.addTemplate('json', require(templatesDir + '/json.template.js'));
 templater.addTemplate('jsonArray', require(templatesDir + '/json_array.template.js'));
 templater.addTemplate('css', require(templatesDir + '/css.template.js'));
 
-templater.addTemplate('jsonTexture', require(templatesDir + '/json_texture.template.js'));
+templater.addTemplate('json_texture', require(templatesDir + '/json_texture.template.js'));
 
 var stylusHandlebars = fs.readFileSync(templatesDir + '/stylus.template.handlebars', 'utf8');
 templater.addHandlebarsTemplate('stylus', stylusHandlebars);

--- a/lib/spritesheet-templates.js
+++ b/lib/spritesheet-templates.js
@@ -315,6 +315,8 @@ templater.addTemplate('json', require(templatesDir + '/json.template.js'));
 templater.addTemplate('jsonArray', require(templatesDir + '/json_array.template.js'));
 templater.addTemplate('css', require(templatesDir + '/css.template.js'));
 
+templater.addTemplate('jsonTexture', require(templatesDir + '/json_texture.template.js'));
+
 var stylusHandlebars = fs.readFileSync(templatesDir + '/stylus.template.handlebars', 'utf8');
 templater.addHandlebarsTemplate('stylus', stylusHandlebars);
 

--- a/lib/templates/json_texture.template.js
+++ b/lib/templates/json_texture.template.js
@@ -1,0 +1,43 @@
+path = require("path");
+
+function jsonTextureTemplate(data) {
+  var spriteObj = {};
+
+  // Create frame data for each sprite.
+  spriteObj.frames={};
+
+  data.sprites.forEach(function (sprite) {
+    var entry={
+      frame: {
+        "x": sprite.x,
+        "y": sprite.y,
+        "w": sprite.width,
+        "h": sprite.height
+      }
+    };
+
+    spriteObj.frames[path.basename(sprite.source_image)]=entry;
+  });
+
+  // Create the meta data.
+  spriteObj.meta = {
+    "app": "spritesheet-templates",
+    "version": "9.5.0",
+    "image": path.basename(data.spritesheet.image),
+    "format": "RGBA8888",
+    "scale": 1,
+    "size": {
+      "w": data.spritesheet.width,
+      "h": data.spritesheet.height
+    }
+  };
+
+  // Stringify the spriteObj
+  var retStr = JSON.stringify(spriteObj, null, 4);
+
+  // Return the stringified JSON
+  return retStr;
+}
+
+// Export our JSON texture template
+module.exports = jsonTextureTemplate;

--- a/lib/templates/json_texture.template.js
+++ b/lib/templates/json_texture.template.js
@@ -1,4 +1,5 @@
 var pkg = require('../../package.json');
+var path = require('path');
 
 function jsonTextureTemplate(data) {
   var spriteObj = {};
@@ -7,6 +8,7 @@ function jsonTextureTemplate(data) {
   spriteObj.frames = {};
 
   data.sprites.forEach(function saveSprite (sprite) {
+    var frameName;
     var entry = {
       frame: {
         x: sprite.x,
@@ -16,7 +18,15 @@ function jsonTextureTemplate(data) {
       }
     };
 
-    spriteObj.frames[sprite.name] = entry;
+    if (sprite.frame_name) {
+      frameName = sprite.frame_name;
+    } else if (sprite.source_image) {
+      frameName = path.basename(sprite.source_image);
+    } else {
+      frameName = sprite.name;
+    }
+
+    spriteObj.frames[frameName] = entry;
   });
 
   // Create the meta data.

--- a/lib/templates/json_texture.template.js
+++ b/lib/templates/json_texture.template.js
@@ -1,34 +1,33 @@
-path = require("path");
+var pkg = require('../../package.json');
 
 function jsonTextureTemplate(data) {
   var spriteObj = {};
 
   // Create frame data for each sprite.
-  spriteObj.frames={};
+  spriteObj.frames = {};
 
-  data.sprites.forEach(function (sprite) {
-    var entry={
+  data.sprites.forEach(function saveSprite (sprite) {
+    var entry = {
       frame: {
-        "x": sprite.x,
-        "y": sprite.y,
-        "w": sprite.width,
-        "h": sprite.height
+        x: sprite.x,
+        y: sprite.y,
+        w: sprite.width,
+        h: sprite.height
       }
     };
 
-    spriteObj.frames[path.basename(sprite.source_image)]=entry;
+    spriteObj.frames[sprite.name] = entry;
   });
 
   // Create the meta data.
   spriteObj.meta = {
-    "app": "spritesheet-templates",
-    "version": "9.5.0",
-    "image": path.basename(data.spritesheet.image),
-    "format": "RGBA8888",
-    "scale": 1,
-    "size": {
-      "w": data.spritesheet.width,
-      "h": data.spritesheet.height
+    app: pkg.name,
+    version: pkg.version,
+    image: data.spritesheet.image,
+    scale: 1,
+    size: {
+      w: data.spritesheet.width,
+      h: data.spritesheet.height
     }
   };
 

--- a/test/expected_files/json_texture.json
+++ b/test/expected_files/json_texture.json
@@ -1,0 +1,38 @@
+{
+    "frames": {
+        "sprite-dash-case": {
+            "frame": {
+                "x": 0,
+                "y": 0,
+                "w": 10,
+                "h": 20
+            }
+        },
+        "sprite_snake_case": {
+            "frame": {
+                "x": 10,
+                "y": 20,
+                "w": 20,
+                "h": 30
+            }
+        },
+        "spriteCamelCase": {
+            "frame": {
+                "x": 30,
+                "y": 50,
+                "w": 50,
+                "h": 50
+            }
+        }
+    },
+    "meta": {
+        "app": "spritesheet-templates",
+        "version": "__VERSION__",
+        "image": "nested/dir/spritesheet.png",
+        "scale": 1,
+        "size": {
+            "w": 80,
+            "h": 100
+        }
+    }
+}

--- a/test/json_texture_test.js
+++ b/test/json_texture_test.js
@@ -1,0 +1,28 @@
+var assert = require('assert');
+var configUtils = require('./utils/config');
+var testUtils = require('./utils/test');
+var fs = require('fs');
+var pkg = require('../package.json');
+
+describe('A hash map of texture info, similar to TexturePacker', function () {
+  testUtils.setInfo(configUtils.multipleSprites);
+
+  function assertValidJson() {
+    it('is valid JSON', function () {
+      var result = this.result;
+      assert.doesNotThrow(function () {
+        JSON.parse(result);
+      });
+    });
+  }
+
+  describe('processed by `spritesheet-templates` into JSON', function () {
+    testUtils.runTemplater({format: 'json_texture'});
+
+    var expected = fs.readFileSync(__dirname + '/expected_files/json_texture.json', 'utf8');
+    expected = expected.replace('__VERSION__', pkg.version);
+    testUtils.assertOutputMatchesString(expected);
+
+    assertValidJson();
+  });
+});

--- a/test/json_texture_test.js
+++ b/test/json_texture_test.js
@@ -1,10 +1,10 @@
 var assert = require('assert');
+var fs = require('fs');
 var configUtils = require('./utils/config');
 var testUtils = require('./utils/test');
-var fs = require('fs');
 var pkg = require('../package.json');
 
-describe('A hash map of texture info, similar to TexturePacker', function () {
+describe('An array of image positions, dimensions, and names', function () {
   testUtils.setInfo(configUtils.multipleSprites);
 
   function assertValidJson() {
@@ -19,9 +19,11 @@ describe('A hash map of texture info, similar to TexturePacker', function () {
   describe('processed by `spritesheet-templates` into JSON', function () {
     testUtils.runTemplater({format: 'json_texture'});
 
-    var expected = fs.readFileSync(__dirname + '/expected_files/json_texture.json', 'utf8');
-    expected = expected.replace('__VERSION__', pkg.version);
-    testUtils.assertOutputMatchesString(expected);
+    it('matches as expected the map of texture info, similar to TexturePacker', function () {
+      var expected = fs.readFileSync(__dirname + '/expected_files/json_texture.json', 'utf8');
+      expected = expected.replace('__VERSION__', pkg.version);
+      assert.strictEqual(this.result, expected);
+    });
 
     assertValidJson();
   });

--- a/test/utils/test.js
+++ b/test/utils/test.js
@@ -42,14 +42,6 @@ exports.assertOutputMatches = function (expectedFilepath) {
   });
 };
 
-exports.assertOutputMatchesString = function (expected) {
-  it('matches as expected', function assertOutputMatchesString () {
-    // Check that the content matches the text
-    var actual = this.result;
-    assert.strictEqual(actual, expected);
-  });
-};
-
 exports.generateCssFile = function (content) {
   before(function generateCssFileFn () {
     // Concatenate content with our result

--- a/test/utils/test.js
+++ b/test/utils/test.js
@@ -42,6 +42,14 @@ exports.assertOutputMatches = function (expectedFilepath) {
   });
 };
 
+exports.assertOutputMatchesString = function (expected) {
+  it('matches as expected', function assertOutputMatchesString () {
+    // Check that the content matches the text
+    var actual = this.result;
+    assert.strictEqual(actual, expected);
+  });
+};
+
 exports.generateCssFile = function (content) {
   before(function generateCssFileFn () {
     // Concatenate content with our result


### PR DESCRIPTION
I added support for a JSON format commonly used for spritesheets in games. I don't know where it comes from originally, but it is at least used by [TexturePacker](https://www.codeandweb.com/texturepacker), [Flash](https://helpx.adobe.com/flash/using/create-sprite-sheet.html) and [PIXI.js](http://www.pixijs.com/).

I have tested a generated spritesheet and it worked to load into PIXI.js. I haven't created a test for unit testing, and in fact it seems like I did something to break it because I use `require('path')`. I think that's why.

So maybe not ready to be merged as it is, but a start!

Any clue why the `require('path')` breaks the tests?