### PR TITLE
Change SASS/SCSS comments to inline style

### DIFF
--- a/lib/templates/sass.template.handlebars
+++ b/lib/templates/sass.template.handlebars
@@ -5,18 +5,16 @@
 }
 
 {{#block "sprites-comment"}}
-/*
-  SASS variables are information about icon's compiled state, stored under its original file name
-
-  .icon-home
-    width: $icon-home-width
-
-  The large array-like variables contain all information about a single icon
-  $icon-home: x y offset_x offset_y width height total_width total_height image_path
-
-  At the bottom of this section, we provide information about the spritesheet itself
-  $spritesheet: width height image $spritesheet-sprites
-  */
+// SASS variables are information about icon's compiled state, stored under its original file name
+//
+// .icon-home
+//   width: $icon-home-width
+//
+// The large array-like variables contain all information about a single icon
+// $icon-home: x y offset_x offset_y width height total_width total_height image_path
+//
+// At the bottom of this section, we provide information about the spritesheet itself
+// $spritesheet: width height image $spritesheet-sprites
 {{/block}}
 {{#block "sprites"}}
 {{#each sprites}}
@@ -43,28 +41,26 @@ ${{spritesheet_info.strings.name}}: ({{spritesheet.px.width}}, {{spritesheet.px.
 
 {{#block "sprite-functions-comment"}}
 {{#if options.functions}}
-/*
-  The provided mixins are intended to be used with the array-like variables
-
-  .icon-home
-    @include sprite-width($icon-home)
-
-  .icon-email
-    @include sprite($icon-email)
-
-  Example usage in HTML:
-    `display: block` sprite:
-    <div class="icon-home"></div>
-
-  To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
-    // CSS
-    .icon {
-      display: inline-block;
-    }
-
-    // HTML
-    <i class="icon icon-home"></i>
-  */
+// The provided mixins are intended to be used with the array-like variables
+//
+// .icon-home
+//   @include sprite-width($icon-home)
+//
+// .icon-email
+//   @include sprite($icon-email)
+//
+// Example usage in HTML:
+//   `display: block` sprite:
+//   <div class="icon-home"></div>
+//
+// To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
+//   // CSS
+//   .icon {
+//     display: inline-block;
+//   }
+//
+//   // HTML
+//   <i class="icon icon-home"></i>
 {{/if}}
 {{/block}}
 {{#block "sprite-functions"}}
@@ -94,12 +90,10 @@ ${{spritesheet_info.strings.name}}: ({{spritesheet.px.width}}, {{spritesheet.px.
 
 {{#block "spritesheet-functions-comment"}}
 {{#if options.functions}}
-/*
-  The `sprites` mixin generates identical output to the CSS template
-    but can be overridden inside of SASS
-
-  @include sprites($spritesheet-sprites)
-  */
+// The `sprites` mixin generates identical output to the CSS template
+//   but can be overridden inside of SASS
+//
+// @include sprites($spritesheet-sprites)
 {{/if}}
 {{/block}}
 {{#block "spritesheet-functions"}}

--- a/lib/templates/sass_retina.template.handlebars
+++ b/lib/templates/sass_retina.template.handlebars
@@ -27,11 +27,9 @@ ${{retina_spritesheet_info.strings.name_image}}: '{{{retina_spritesheet.escaped_
 ${{retina_spritesheet_info.strings.name_sprites}}: ({{#each retina_sprites}}${{strings.name}}, {{/each}})
 ${{retina_spritesheet_info.strings.name}}: ({{retina_spritesheet.px.width}}, {{retina_spritesheet.px.height}}, '{{{retina_spritesheet.escaped_image}}}', ${{retina_spritesheet_info.strings.name_sprites}}, )
 
-/*
-  These "retina group" variables are mappings for the naming and pairing of normal and retina sprites.
-
-  The list formatted variables are intended for mixins like `retina-sprite` and `retina-sprites`.
-  */
+// These "retina group" variables are mappings for the naming and pairing of normal and retina sprites.
+//
+// The list formatted variables are intended for mixins like `retina-sprite` and `retina-sprites`.
 {{#each retina_groups}}
 ${{strings.name_group_name}}: '{{name}}'
 ${{strings.name_group}}: ('{{name}}', ${{normal.strings.name}}, ${{retina.strings.name}}, )
@@ -42,17 +40,15 @@ ${{retina_groups_info.strings.name}}: ({{#each retina_groups}}${{strings.name_gr
 {{#content "sprite-functions" mode="append"}}
 {{#if options.functions}}
 
-/*
-  The `retina-sprite` mixin sets up rules and a media query for a sprite/retina sprite.
-    It should be used with a "retina group" variable.
-
-  The media query is from CSS Tricks: https://css-tricks.com/snippets/css/retina-display-media-query/
-
-  $icon-home-group: ('icon-home', $icon-home, $icon-home-2x, )
-
-  .icon-home
-    @include retina-sprite($icon-home-group)
-  */
+// The `retina-sprite` mixin sets up rules and a media query for a sprite/retina sprite.
+//   It should be used with a "retina group" variable.
+//
+// The media query is from CSS Tricks: https://css-tricks.com/snippets/css/retina-display-media-query/
+//
+// $icon-home-group: ('icon-home', $icon-home, $icon-home-2x, )
+//
+// .icon-home
+//   @include retina-sprite($icon-home-group)
 @mixin sprite-background-size($sprite)
   $sprite-total-width: nth($sprite, 7)
   $sprite-total-height: nth($sprite, 8)
@@ -72,12 +68,10 @@ ${{retina_groups_info.strings.name}}: ({{#each retina_groups}}${{strings.name_gr
 {{#content "spritesheet-functions" mode="append"}}
 {{#if options.functions}}
 
-/*
-  The `retina-sprites` mixin generates a CSS rule and media query for retina groups
-    This yields the same output as CSS retina template but can be overridden in SASS
-
-  @include retina-sprites($retina-groups)
-  */
+// The `retina-sprites` mixin generates a CSS rule and media query for retina groups
+//   This yields the same output as CSS retina template but can be overridden in SASS
+//
+// @include retina-sprites($retina-groups)
 @mixin retina-sprites($retina-groups)
   @each $retina-group in $retina-groups
     $sprite-name: nth($retina-group, 1)

--- a/lib/templates/scss.template.handlebars
+++ b/lib/templates/scss.template.handlebars
@@ -5,19 +5,17 @@
 }
 
 {{#block "sprites-comment"}}
-/*
-SCSS variables are information about icon's compiled state, stored under its original file name
-
-.icon-home {
-  width: $icon-home-width;
-}
-
-The large array-like variables contain all information about a single icon
-$icon-home: x y offset_x offset_y width height total_width total_height image_path;
-
-At the bottom of this section, we provide information about the spritesheet itself
-$spritesheet: width height image $spritesheet-sprites;
-*/
+// SCSS variables are information about icon's compiled state, stored under its original file name
+//
+// .icon-home {
+//   width: $icon-home-width;
+// }
+//
+// The large array-like variables contain all information about a single icon
+// $icon-home: x y offset_x offset_y width height total_width total_height image_path;
+//
+// At the bottom of this section, we provide information about the spritesheet itself
+// $spritesheet: width height image $spritesheet-sprites;
 {{/block}}
 {{#block "sprites"}}
 {{#each sprites}}
@@ -44,32 +42,30 @@ ${{spritesheet_info.strings.name}}: ({{spritesheet.px.width}}, {{spritesheet.px.
 
 {{#block "sprite-functions-comment"}}
 {{#if options.functions}}
-/*
-The provided mixins are intended to be used with the array-like variables
-
-.icon-home {
-  @include sprite-width($icon-home);
-}
-
-.icon-email {
-  @include sprite($icon-email);
-}
-
-Example usage in HTML:
-
-`display: block` sprite:
-<div class="icon-home"></div>
-
-To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
-
-// CSS
-.icon {
-  display: inline-block;
-}
-
-// HTML
-<i class="icon icon-home"></i>
-*/
+// The provided mixins are intended to be used with the array-like variables
+//
+// .icon-home {
+//   @include sprite-width($icon-home);
+// }
+//
+// .icon-email {
+//   @include sprite($icon-email);
+// }
+//
+// Example usage in HTML:
+//
+// `display: block` sprite:
+// <div class="icon-home"></div>
+//
+// To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
+//
+// // CSS
+// .icon {
+//   display: inline-block;
+// }
+//
+// // HTML
+// <i class="icon icon-home"></i>
 {{/if}}
 {{/block}}
 {{#block "sprite-functions"}}
@@ -104,12 +100,10 @@ To change `display` (e.g. `display: inline-block;`), we suggest using a common C
 
 {{#block "spritesheet-functions-comment"}}
 {{#if options.functions}}
-/*
-The `sprites` mixin generates identical output to the CSS template
-  but can be overridden inside of SCSS
-
-@include sprites($spritesheet-sprites);
-*/
+// The `sprites` mixin generates identical output to the CSS template
+//   but can be overridden inside of SCSS
+//
+// @include sprites($spritesheet-sprites);
 {{/if}}
 {{/block}}
 {{#block "spritesheet-functions"}}

--- a/lib/templates/scss_maps.template.handlebars
+++ b/lib/templates/scss_maps.template.handlebars
@@ -5,15 +5,13 @@
 }
 
 {{#block "sprites-comment"}}
-/*
-SCSS variables are information about icon's compiled state, stored under its original file name
-
-.icon-home {
-  width: map-get($icon-home, 'width');
-}
-
-At the bottom of this section, we provide information about the spritesheet itself
-*/
+// SCSS variables are information about icon's compiled state, stored under its original file name
+//
+// .icon-home {
+//   width: map-get($icon-home, 'width');
+// }
+//
+// At the bottom of this section, we provide information about the spritesheet itself
 {{/block}}
 {{#block "sprites"}}
 {{#each sprites}}
@@ -42,32 +40,30 @@ ${{spritesheet_info.strings.name}}: (
 
 {{#block "sprite-functions-comment"}}
 {{#if options.functions}}
-/*
-The provided mixins are intended to be used with variables directly
-
-.icon-home {
-  @include sprite-width($icon-home);
-}
-
-.icon-email {
-  @include sprite($icon-email);
-}
-
-Example usage in HTML:
-
-`display: block` sprite:
-<div class="icon-home"></div>
-
-To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
-
-// CSS
-.icon {
-  display: inline-block;
-}
-
-// HTML
-<i class="icon icon-home"></i>
-*/
+// The provided mixins are intended to be used with variables directly
+//
+// .icon-home {
+//   @include sprite-width($icon-home);
+// }
+//
+// .icon-email {
+//   @include sprite($icon-email);
+// }
+//
+// Example usage in HTML:
+//
+// `display: block` sprite:
+// <div class="icon-home"></div>
+//
+// To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
+//
+// // CSS
+// .icon {
+//   display: inline-block;
+// }
+//
+// // HTML
+// <i class="icon icon-home"></i>
 {{/if}}
 {{/block}}
 {{#block "sprite-functions"}}
@@ -99,12 +95,10 @@ To change `display` (e.g. `display: inline-block;`), we suggest using a common C
 
 {{#block "spritesheet-functions-comment"}}
 {{#if options.functions}}
-/*
-The `sprites` mixin generates identical output to the CSS template
-  but can be overridden inside of SCSS
-
-@include sprites(map-get($spritesheet, '{{strings.bare_sprites}}'));
-*/
+// The `sprites` mixin generates identical output to the CSS template
+//   but can be overridden inside of SCSS
+//
+// @include sprites(map-get($spritesheet, '{{strings.bare_sprites}}'));
 {{/if}}
 {{/block}}
 {{#block "spritesheet-functions"}}

--- a/lib/templates/scss_maps_retina.template.handlebars
+++ b/lib/templates/scss_maps_retina.template.handlebars
@@ -29,11 +29,9 @@ ${{retina_spritesheet_info.strings.name}}: (
   {{retina_spritesheet_info.strings.bare_sprites}}: ({{#each retina_sprites}}${{strings.name}}, {{/each}})
 );
 
-/*
-These "retina group" variables are mappings for the naming and pairing of normal and retina sprites.
-
-The map variables are intended for the `retina-sprite` mixin. The list variable is for `retina-sprites`.
-*/
+// These "retina group" variables are mappings for the naming and pairing of normal and retina sprites.
+//
+// The map variables are intended for the `retina-sprite` mixin. The list variable is for `retina-sprites`.
 {{#each retina_groups}}
 ${{strings.name_group}}: (
   {{strings.bare_name}}: '{{name}}',
@@ -47,22 +45,20 @@ ${{retina_groups_info.strings.name}}: ({{#each retina_groups}}${{strings.name_gr
 {{#content "sprite-functions" mode="append"}}
 {{#if options.functions}}
 
-/*
-The `retina-sprite` mixin sets up rules and a media query for a sprite/retina sprite.
-  It should be used with a "retina group" variable.
-
-The media query is from CSS Tricks: https://css-tricks.com/snippets/css/retina-display-media-query/
-
-$icon-home-group: (
-  name: 'icon-home',
-  normal: $icon-home,
-  retina: $icon-home-2x
-);
-
-.icon-home {
-  @include retina-sprite($icon-home-group);
-}
-*/
+// The `retina-sprite` mixin sets up rules and a media query for a sprite/retina sprite.
+//   It should be used with a "retina group" variable.
+//
+// The media query is from CSS Tricks: https://css-tricks.com/snippets/css/retina-display-media-query/
+//
+// $icon-home-group: (
+//   name: 'icon-home',
+//   normal: $icon-home,
+//   retina: $icon-home-2x
+// );
+//
+// .icon-home {
+//   @include retina-sprite($icon-home-group);
+// }
 @mixin sprite-background-size($sprite) {
   background-size: map-get($sprite, '{{strings.bare_total_width}}') map-get($sprite, '{{strings.bare_total_height}}');
 }
@@ -84,12 +80,10 @@ $icon-home-group: (
 {{#content "spritesheet-functions" mode="append"}}
 {{#if options.functions}}
 
-/*
-The `retina-sprites` mixin generates a CSS rule and media query for retina groups
-  This yields the same output as CSS retina template but can be overridden in SCSS
-
-@include retina-sprites($retina-groups);
-*/
+// The `retina-sprites` mixin generates a CSS rule and media query for retina groups
+//   This yields the same output as CSS retina template but can be overridden in SCSS
+//
+// @include retina-sprites($retina-groups);
 @mixin retina-sprites($retina-groups) {
   @each $retina-group in $retina-groups {
     $sprite-name: map-get($retina-group, '{{strings.bare_name}}');

--- a/lib/templates/scss_retina.template.handlebars
+++ b/lib/templates/scss_retina.template.handlebars
@@ -27,11 +27,9 @@ ${{retina_spritesheet_info.strings.name_image}}: '{{{retina_spritesheet.escaped_
 ${{retina_spritesheet_info.strings.name_sprites}}: ({{#each retina_sprites}}${{strings.name}}, {{/each}});
 ${{retina_spritesheet_info.strings.name}}: ({{retina_spritesheet.px.width}}, {{retina_spritesheet.px.height}}, '{{{retina_spritesheet.escaped_image}}}', ${{retina_spritesheet_info.strings.name_sprites}}, );
 
-/*
-These "retina group" variables are mappings for the naming and pairing of normal and retina sprites.
-
-The list formatted variables are intended for mixins like `retina-sprite` and `retina-sprites`.
-*/
+// These "retina group" variables are mappings for the naming and pairing of normal and retina sprites.
+//
+// The list formatted variables are intended for mixins like `retina-sprite` and `retina-sprites`.
 {{#each retina_groups}}
 ${{strings.name_group_name}}: '{{name}}';
 ${{strings.name_group}}: ('{{name}}', ${{normal.strings.name}}, ${{retina.strings.name}}, );
@@ -42,18 +40,16 @@ ${{retina_groups_info.strings.name}}: ({{#each retina_groups}}${{strings.name_gr
 {{#content "sprite-functions" mode="append"}}
 {{#if options.functions}}
 
-/*
-The `retina-sprite` mixin sets up rules and a media query for a sprite/retina sprite.
-  It should be used with a "retina group" variable.
-
-The media query is from CSS Tricks: https://css-tricks.com/snippets/css/retina-display-media-query/
-
-$icon-home-group: ('icon-home', $icon-home, $icon-home-2x, );
-
-.icon-home {
-  @include retina-sprite($icon-home-group);
-}
-*/
+// The `retina-sprite` mixin sets up rules and a media query for a sprite/retina sprite.
+//   It should be used with a "retina group" variable.
+//
+// The media query is from CSS Tricks: https://css-tricks.com/snippets/css/retina-display-media-query/
+//
+// $icon-home-group: ('icon-home', $icon-home, $icon-home-2x, );
+//
+// .icon-home {
+//   @include retina-sprite($icon-home-group);
+// }
 @mixin sprite-background-size($sprite) {
   $sprite-total-width: nth($sprite, 7);
   $sprite-total-height: nth($sprite, 8);
@@ -77,12 +73,10 @@ $icon-home-group: ('icon-home', $icon-home, $icon-home-2x, );
 {{#content "spritesheet-functions" mode="append"}}
 {{#if options.functions}}
 
-/*
-The `retina-sprites` mixin generates a CSS rule and media query for retina groups
-  This yields the same output as CSS retina template but can be overridden in SCSS
-
-@include retina-sprites($retina-groups);
-*/
+// The `retina-sprites` mixin generates a CSS rule and media query for retina groups
+//   This yields the same output as CSS retina template but can be overridden in SCSS
+//
+// @include retina-sprites($retina-groups);
 @mixin retina-sprites($retina-groups) {
   @each $retina-group in $retina-groups {
     $sprite-name: nth($retina-group, 1);

--- a/test/expected_files/sass-single.sass
+++ b/test/expected_files/sass-single.sass
@@ -1,15 +1,13 @@
-/*
-  SASS variables are information about icon's compiled state, stored under its original file name
-
-  .icon-home
-    width: $icon-home-width
-
-  The large array-like variables contain all information about a single icon
-  $icon-home: x y offset_x offset_y width height total_width total_height image_path
-
-  At the bottom of this section, we provide information about the spritesheet itself
-  $spritesheet: width height image $spritesheet-sprites
-  */
+// SASS variables are information about icon's compiled state, stored under its original file name
+//
+// .icon-home
+//   width: $icon-home-width
+//
+// The large array-like variables contain all information about a single icon
+// $icon-home: x y offset_x offset_y width height total_width total_height image_path
+//
+// At the bottom of this section, we provide information about the spritesheet itself
+// $spritesheet: width height image $spritesheet-sprites
 $sprite-dash-case-name: 'sprite-dash-case'
 $sprite-dash-case-x: 0px
 $sprite-dash-case-y: 0px
@@ -27,28 +25,26 @@ $spritesheet-image: 'nested/dir/spritesheet.png'
 $spritesheet-sprites: ($sprite-dash-case, )
 $spritesheet: (10px, 20px, 'nested/dir/spritesheet.png', $spritesheet-sprites, )
 
-/*
-  The provided mixins are intended to be used with the array-like variables
-
-  .icon-home
-    @include sprite-width($icon-home)
-
-  .icon-email
-    @include sprite($icon-email)
-
-  Example usage in HTML:
-    `display: block` sprite:
-    <div class="icon-home"></div>
-
-  To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
-    // CSS
-    .icon {
-      display: inline-block;
-    }
-
-    // HTML
-    <i class="icon icon-home"></i>
-  */
+// The provided mixins are intended to be used with the array-like variables
+//
+// .icon-home
+//   @include sprite-width($icon-home)
+//
+// .icon-email
+//   @include sprite($icon-email)
+//
+// Example usage in HTML:
+//   `display: block` sprite:
+//   <div class="icon-home"></div>
+//
+// To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
+//   // CSS
+//   .icon {
+//     display: inline-block;
+//   }
+//
+//   // HTML
+//   <i class="icon icon-home"></i>
 @mixin sprite-width($sprite)
   width: nth($sprite, 5)
 
@@ -70,12 +66,10 @@ $spritesheet: (10px, 20px, 'nested/dir/spritesheet.png', $spritesheet-sprites, )
   @include sprite-width($sprite)
   @include sprite-height($sprite)
 
-/*
-  The `sprites` mixin generates identical output to the CSS template
-    but can be overridden inside of SASS
-
-  @include sprites($spritesheet-sprites)
-  */
+// The `sprites` mixin generates identical output to the CSS template
+//   but can be overridden inside of SASS
+//
+// @include sprites($spritesheet-sprites)
 @mixin sprites($sprites)
   @each $sprite in $sprites
     $sprite-name: nth($sprite, 10)

--- a/test/expected_files/sass.sass
+++ b/test/expected_files/sass.sass
@@ -1,15 +1,13 @@
-/*
-  SASS variables are information about icon's compiled state, stored under its original file name
-
-  .icon-home
-    width: $icon-home-width
-
-  The large array-like variables contain all information about a single icon
-  $icon-home: x y offset_x offset_y width height total_width total_height image_path
-
-  At the bottom of this section, we provide information about the spritesheet itself
-  $spritesheet: width height image $spritesheet-sprites
-  */
+// SASS variables are information about icon's compiled state, stored under its original file name
+//
+// .icon-home
+//   width: $icon-home-width
+//
+// The large array-like variables contain all information about a single icon
+// $icon-home: x y offset_x offset_y width height total_width total_height image_path
+//
+// At the bottom of this section, we provide information about the spritesheet itself
+// $spritesheet: width height image $spritesheet-sprites
 $sprite-dash-case-name: 'sprite-dash-case'
 $sprite-dash-case-x: 0px
 $sprite-dash-case-y: 0px
@@ -49,28 +47,26 @@ $spritesheet-image: 'nested/dir/spritesheet.png'
 $spritesheet-sprites: ($sprite-dash-case, $sprite-snake-case, $sprite-camel-case, )
 $spritesheet: (80px, 100px, 'nested/dir/spritesheet.png', $spritesheet-sprites, )
 
-/*
-  The provided mixins are intended to be used with the array-like variables
-
-  .icon-home
-    @include sprite-width($icon-home)
-
-  .icon-email
-    @include sprite($icon-email)
-
-  Example usage in HTML:
-    `display: block` sprite:
-    <div class="icon-home"></div>
-
-  To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
-    // CSS
-    .icon {
-      display: inline-block;
-    }
-
-    // HTML
-    <i class="icon icon-home"></i>
-  */
+// The provided mixins are intended to be used with the array-like variables
+//
+// .icon-home
+//   @include sprite-width($icon-home)
+//
+// .icon-email
+//   @include sprite($icon-email)
+//
+// Example usage in HTML:
+//   `display: block` sprite:
+//   <div class="icon-home"></div>
+//
+// To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
+//   // CSS
+//   .icon {
+//     display: inline-block;
+//   }
+//
+//   // HTML
+//   <i class="icon icon-home"></i>
 @mixin sprite-width($sprite)
   width: nth($sprite, 5)
 
@@ -92,12 +88,10 @@ $spritesheet: (80px, 100px, 'nested/dir/spritesheet.png', $spritesheet-sprites, 
   @include sprite-width($sprite)
   @include sprite-height($sprite)
 
-/*
-  The `sprites` mixin generates identical output to the CSS template
-    but can be overridden inside of SASS
-
-  @include sprites($spritesheet-sprites)
-  */
+// The `sprites` mixin generates identical output to the CSS template
+//   but can be overridden inside of SASS
+//
+// @include sprites($spritesheet-sprites)
 @mixin sprites($sprites)
   @each $sprite in $sprites
     $sprite-name: nth($sprite, 10)

--- a/test/expected_files/sass_retina.sass
+++ b/test/expected_files/sass_retina.sass
@@ -1,15 +1,13 @@
-/*
-  SASS variables are information about icon's compiled state, stored under its original file name
-
-  .icon-home
-    width: $icon-home-width
-
-  The large array-like variables contain all information about a single icon
-  $icon-home: x y offset_x offset_y width height total_width total_height image_path
-
-  At the bottom of this section, we provide information about the spritesheet itself
-  $spritesheet: width height image $spritesheet-sprites
-  */
+// SASS variables are information about icon's compiled state, stored under its original file name
+//
+// .icon-home
+//   width: $icon-home-width
+//
+// The large array-like variables contain all information about a single icon
+// $icon-home: x y offset_x offset_y width height total_width total_height image_path
+//
+// At the bottom of this section, we provide information about the spritesheet itself
+// $spritesheet: width height image $spritesheet-sprites
 $sprite-dash-case-name: 'sprite-dash-case'
 $sprite-dash-case-x: 0px
 $sprite-dash-case-y: 0px
@@ -87,11 +85,9 @@ $retina-spritesheet-image: 'nested/dir/spritesheet@2x.png'
 $retina-spritesheet-sprites: ($sprite-dash-case-2x, $sprite-snake-case-2x, $sprite-camel-case-2x, )
 $retina-spritesheet: (160px, 200px, 'nested/dir/spritesheet@2x.png', $retina-spritesheet-sprites, )
 
-/*
-  These "retina group" variables are mappings for the naming and pairing of normal and retina sprites.
-
-  The list formatted variables are intended for mixins like `retina-sprite` and `retina-sprites`.
-  */
+// These "retina group" variables are mappings for the naming and pairing of normal and retina sprites.
+//
+// The list formatted variables are intended for mixins like `retina-sprite` and `retina-sprites`.
 $sprite-dash-case-group-name: 'sprite-dash-case'
 $sprite-dash-case-group: ('sprite-dash-case', $sprite-dash-case, $sprite-dash-case-2x, )
 $sprite-snake-case-group-name: 'sprite_snake_case'
@@ -100,28 +96,26 @@ $sprite-camel-case-group-name: 'spriteCamelCase'
 $sprite-camel-case-group: ('spriteCamelCase', $sprite-camel-case, $sprite-camel-case-2x, )
 $retina-groups: ($sprite-dash-case-group, $sprite-snake-case-group, $sprite-camel-case-group, )
 
-/*
-  The provided mixins are intended to be used with the array-like variables
-
-  .icon-home
-    @include sprite-width($icon-home)
-
-  .icon-email
-    @include sprite($icon-email)
-
-  Example usage in HTML:
-    `display: block` sprite:
-    <div class="icon-home"></div>
-
-  To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
-    // CSS
-    .icon {
-      display: inline-block;
-    }
-
-    // HTML
-    <i class="icon icon-home"></i>
-  */
+// The provided mixins are intended to be used with the array-like variables
+//
+// .icon-home
+//   @include sprite-width($icon-home)
+//
+// .icon-email
+//   @include sprite($icon-email)
+//
+// Example usage in HTML:
+//   `display: block` sprite:
+//   <div class="icon-home"></div>
+//
+// To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
+//   // CSS
+//   .icon {
+//     display: inline-block;
+//   }
+//
+//   // HTML
+//   <i class="icon icon-home"></i>
 @mixin sprite-width($sprite)
   width: nth($sprite, 5)
 
@@ -143,17 +137,15 @@ $retina-groups: ($sprite-dash-case-group, $sprite-snake-case-group, $sprite-came
   @include sprite-width($sprite)
   @include sprite-height($sprite)
 
-/*
-  The `retina-sprite` mixin sets up rules and a media query for a sprite/retina sprite.
-    It should be used with a "retina group" variable.
-
-  The media query is from CSS Tricks: https://css-tricks.com/snippets/css/retina-display-media-query/
-
-  $icon-home-group: ('icon-home', $icon-home, $icon-home-2x, )
-
-  .icon-home
-    @include retina-sprite($icon-home-group)
-  */
+// The `retina-sprite` mixin sets up rules and a media query for a sprite/retina sprite.
+//   It should be used with a "retina group" variable.
+//
+// The media query is from CSS Tricks: https://css-tricks.com/snippets/css/retina-display-media-query/
+//
+// $icon-home-group: ('icon-home', $icon-home, $icon-home-2x, )
+//
+// .icon-home
+//   @include retina-sprite($icon-home-group)
 @mixin sprite-background-size($sprite)
   $sprite-total-width: nth($sprite, 7)
   $sprite-total-height: nth($sprite, 8)
@@ -168,24 +160,20 @@ $retina-groups: ($sprite-dash-case-group, $sprite-snake-case-group, $sprite-came
     @include sprite-image($retina-sprite)
     @include sprite-background-size($normal-sprite)
 
-/*
-  The `sprites` mixin generates identical output to the CSS template
-    but can be overridden inside of SASS
-
-  @include sprites($spritesheet-sprites)
-  */
+// The `sprites` mixin generates identical output to the CSS template
+//   but can be overridden inside of SASS
+//
+// @include sprites($spritesheet-sprites)
 @mixin sprites($sprites)
   @each $sprite in $sprites
     $sprite-name: nth($sprite, 10)
     .#{$sprite-name}
       @include sprite($sprite)
 
-/*
-  The `retina-sprites` mixin generates a CSS rule and media query for retina groups
-    This yields the same output as CSS retina template but can be overridden in SASS
-
-  @include retina-sprites($retina-groups)
-  */
+// The `retina-sprites` mixin generates a CSS rule and media query for retina groups
+//   This yields the same output as CSS retina template but can be overridden in SASS
+//
+// @include retina-sprites($retina-groups)
 @mixin retina-sprites($retina-groups)
   @each $retina-group in $retina-groups
     $sprite-name: nth($retina-group, 1)

--- a/test/expected_files/scss-single.scss
+++ b/test/expected_files/scss-single.scss
@@ -1,16 +1,14 @@
-/*
-SCSS variables are information about icon's compiled state, stored under its original file name
-
-.icon-home {
-  width: $icon-home-width;
-}
-
-The large array-like variables contain all information about a single icon
-$icon-home: x y offset_x offset_y width height total_width total_height image_path;
-
-At the bottom of this section, we provide information about the spritesheet itself
-$spritesheet: width height image $spritesheet-sprites;
-*/
+// SCSS variables are information about icon's compiled state, stored under its original file name
+//
+// .icon-home {
+//   width: $icon-home-width;
+// }
+//
+// The large array-like variables contain all information about a single icon
+// $icon-home: x y offset_x offset_y width height total_width total_height image_path;
+//
+// At the bottom of this section, we provide information about the spritesheet itself
+// $spritesheet: width height image $spritesheet-sprites;
 $sprite-dash-case-name: 'sprite-dash-case';
 $sprite-dash-case-x: 0px;
 $sprite-dash-case-y: 0px;
@@ -28,32 +26,30 @@ $spritesheet-image: 'nested/dir/spritesheet.png';
 $spritesheet-sprites: ($sprite-dash-case, );
 $spritesheet: (10px, 20px, 'nested/dir/spritesheet.png', $spritesheet-sprites, );
 
-/*
-The provided mixins are intended to be used with the array-like variables
-
-.icon-home {
-  @include sprite-width($icon-home);
-}
-
-.icon-email {
-  @include sprite($icon-email);
-}
-
-Example usage in HTML:
-
-`display: block` sprite:
-<div class="icon-home"></div>
-
-To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
-
-// CSS
-.icon {
-  display: inline-block;
-}
-
-// HTML
-<i class="icon icon-home"></i>
-*/
+// The provided mixins are intended to be used with the array-like variables
+//
+// .icon-home {
+//   @include sprite-width($icon-home);
+// }
+//
+// .icon-email {
+//   @include sprite($icon-email);
+// }
+//
+// Example usage in HTML:
+//
+// `display: block` sprite:
+// <div class="icon-home"></div>
+//
+// To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
+//
+// // CSS
+// .icon {
+//   display: inline-block;
+// }
+//
+// // HTML
+// <i class="icon icon-home"></i>
 @mixin sprite-width($sprite) {
   width: nth($sprite, 5);
 }
@@ -80,12 +76,10 @@ To change `display` (e.g. `display: inline-block;`), we suggest using a common C
   @include sprite-height($sprite);
 }
 
-/*
-The `sprites` mixin generates identical output to the CSS template
-  but can be overridden inside of SCSS
-
-@include sprites($spritesheet-sprites);
-*/
+// The `sprites` mixin generates identical output to the CSS template
+//   but can be overridden inside of SCSS
+//
+// @include sprites($spritesheet-sprites);
 @mixin sprites($sprites) {
   @each $sprite in $sprites {
     $sprite-name: nth($sprite, 10);

--- a/test/expected_files/scss.scss
+++ b/test/expected_files/scss.scss
@@ -1,16 +1,14 @@
-/*
-SCSS variables are information about icon's compiled state, stored under its original file name
-
-.icon-home {
-  width: $icon-home-width;
-}
-
-The large array-like variables contain all information about a single icon
-$icon-home: x y offset_x offset_y width height total_width total_height image_path;
-
-At the bottom of this section, we provide information about the spritesheet itself
-$spritesheet: width height image $spritesheet-sprites;
-*/
+// SCSS variables are information about icon's compiled state, stored under its original file name
+//
+// .icon-home {
+//   width: $icon-home-width;
+// }
+//
+// The large array-like variables contain all information about a single icon
+// $icon-home: x y offset_x offset_y width height total_width total_height image_path;
+//
+// At the bottom of this section, we provide information about the spritesheet itself
+// $spritesheet: width height image $spritesheet-sprites;
 $sprite-dash-case-name: 'sprite-dash-case';
 $sprite-dash-case-x: 0px;
 $sprite-dash-case-y: 0px;
@@ -50,32 +48,30 @@ $spritesheet-image: 'nested/dir/spritesheet.png';
 $spritesheet-sprites: ($sprite-dash-case, $sprite-snake-case, $sprite-camel-case, );
 $spritesheet: (80px, 100px, 'nested/dir/spritesheet.png', $spritesheet-sprites, );
 
-/*
-The provided mixins are intended to be used with the array-like variables
-
-.icon-home {
-  @include sprite-width($icon-home);
-}
-
-.icon-email {
-  @include sprite($icon-email);
-}
-
-Example usage in HTML:
-
-`display: block` sprite:
-<div class="icon-home"></div>
-
-To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
-
-// CSS
-.icon {
-  display: inline-block;
-}
-
-// HTML
-<i class="icon icon-home"></i>
-*/
+// The provided mixins are intended to be used with the array-like variables
+//
+// .icon-home {
+//   @include sprite-width($icon-home);
+// }
+//
+// .icon-email {
+//   @include sprite($icon-email);
+// }
+//
+// Example usage in HTML:
+//
+// `display: block` sprite:
+// <div class="icon-home"></div>
+//
+// To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
+//
+// // CSS
+// .icon {
+//   display: inline-block;
+// }
+//
+// // HTML
+// <i class="icon icon-home"></i>
 @mixin sprite-width($sprite) {
   width: nth($sprite, 5);
 }
@@ -102,12 +98,10 @@ To change `display` (e.g. `display: inline-block;`), we suggest using a common C
   @include sprite-height($sprite);
 }
 
-/*
-The `sprites` mixin generates identical output to the CSS template
-  but can be overridden inside of SCSS
-
-@include sprites($spritesheet-sprites);
-*/
+// The `sprites` mixin generates identical output to the CSS template
+//   but can be overridden inside of SCSS
+//
+// @include sprites($spritesheet-sprites);
 @mixin sprites($sprites) {
   @each $sprite in $sprites {
     $sprite-name: nth($sprite, 10);

--- a/test/expected_files/scss_maps-single.scss
+++ b/test/expected_files/scss_maps-single.scss
@@ -1,12 +1,10 @@
-/*
-SCSS variables are information about icon's compiled state, stored under its original file name
-
-.icon-home {
-  width: map-get($icon-home, 'width');
-}
-
-At the bottom of this section, we provide information about the spritesheet itself
-*/
+// SCSS variables are information about icon's compiled state, stored under its original file name
+//
+// .icon-home {
+//   width: map-get($icon-home, 'width');
+// }
+//
+// At the bottom of this section, we provide information about the spritesheet itself
 $sprite-dash-case: (
   name: 'sprite-dash-case',
   x: 0px,
@@ -26,32 +24,30 @@ $spritesheet: (
   sprites: ($sprite-dash-case, )
 );
 
-/*
-The provided mixins are intended to be used with variables directly
-
-.icon-home {
-  @include sprite-width($icon-home);
-}
-
-.icon-email {
-  @include sprite($icon-email);
-}
-
-Example usage in HTML:
-
-`display: block` sprite:
-<div class="icon-home"></div>
-
-To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
-
-// CSS
-.icon {
-  display: inline-block;
-}
-
-// HTML
-<i class="icon icon-home"></i>
-*/
+// The provided mixins are intended to be used with variables directly
+//
+// .icon-home {
+//   @include sprite-width($icon-home);
+// }
+//
+// .icon-email {
+//   @include sprite($icon-email);
+// }
+//
+// Example usage in HTML:
+//
+// `display: block` sprite:
+// <div class="icon-home"></div>
+//
+// To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
+//
+// // CSS
+// .icon {
+//   display: inline-block;
+// }
+//
+// // HTML
+// <i class="icon icon-home"></i>
 @mixin sprite-width($sprite) {
   width: map-get($sprite, 'width');
 }
@@ -75,12 +71,10 @@ To change `display` (e.g. `display: inline-block;`), we suggest using a common C
   @include sprite-height($sprite);
 }
 
-/*
-The `sprites` mixin generates identical output to the CSS template
-  but can be overridden inside of SCSS
-
-@include sprites(map-get($spritesheet, 'sprites'));
-*/
+// The `sprites` mixin generates identical output to the CSS template
+//   but can be overridden inside of SCSS
+//
+// @include sprites(map-get($spritesheet, 'sprites'));
 @mixin sprites($sprites) {
   @each $sprite in $sprites {
     $sprite-name: map-get($sprite, 'name');

--- a/test/expected_files/scss_maps.scss
+++ b/test/expected_files/scss_maps.scss
@@ -1,12 +1,10 @@
-/*
-SCSS variables are information about icon's compiled state, stored under its original file name
-
-.icon-home {
-  width: map-get($icon-home, 'width');
-}
-
-At the bottom of this section, we provide information about the spritesheet itself
-*/
+// SCSS variables are information about icon's compiled state, stored under its original file name
+//
+// .icon-home {
+//   width: map-get($icon-home, 'width');
+// }
+//
+// At the bottom of this section, we provide information about the spritesheet itself
 $sprite-dash-case: (
   name: 'sprite-dash-case',
   x: 0px,
@@ -50,32 +48,30 @@ $spritesheet: (
   sprites: ($sprite-dash-case, $sprite-snake-case, $sprite-camel-case, )
 );
 
-/*
-The provided mixins are intended to be used with variables directly
-
-.icon-home {
-  @include sprite-width($icon-home);
-}
-
-.icon-email {
-  @include sprite($icon-email);
-}
-
-Example usage in HTML:
-
-`display: block` sprite:
-<div class="icon-home"></div>
-
-To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
-
-// CSS
-.icon {
-  display: inline-block;
-}
-
-// HTML
-<i class="icon icon-home"></i>
-*/
+// The provided mixins are intended to be used with variables directly
+//
+// .icon-home {
+//   @include sprite-width($icon-home);
+// }
+//
+// .icon-email {
+//   @include sprite($icon-email);
+// }
+//
+// Example usage in HTML:
+//
+// `display: block` sprite:
+// <div class="icon-home"></div>
+//
+// To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
+//
+// // CSS
+// .icon {
+//   display: inline-block;
+// }
+//
+// // HTML
+// <i class="icon icon-home"></i>
 @mixin sprite-width($sprite) {
   width: map-get($sprite, 'width');
 }
@@ -99,12 +95,10 @@ To change `display` (e.g. `display: inline-block;`), we suggest using a common C
   @include sprite-height($sprite);
 }
 
-/*
-The `sprites` mixin generates identical output to the CSS template
-  but can be overridden inside of SCSS
-
-@include sprites(map-get($spritesheet, 'sprites'));
-*/
+// The `sprites` mixin generates identical output to the CSS template
+//   but can be overridden inside of SCSS
+//
+// @include sprites(map-get($spritesheet, 'sprites'));
 @mixin sprites($sprites) {
   @each $sprite in $sprites {
     $sprite-name: map-get($sprite, 'name');

--- a/test/expected_files/scss_maps_retina.scss
+++ b/test/expected_files/scss_maps_retina.scss
@@ -1,12 +1,10 @@
-/*
-SCSS variables are information about icon's compiled state, stored under its original file name
-
-.icon-home {
-  width: map-get($icon-home, 'width');
-}
-
-At the bottom of this section, we provide information about the spritesheet itself
-*/
+// SCSS variables are information about icon's compiled state, stored under its original file name
+//
+// .icon-home {
+//   width: map-get($icon-home, 'width');
+// }
+//
+// At the bottom of this section, we provide information about the spritesheet itself
 $sprite-dash-case: (
   name: 'sprite-dash-case',
   x: 0px,
@@ -92,11 +90,9 @@ $retina-spritesheet: (
   sprites: ($sprite-dash-case-2x, $sprite-snake-case-2x, $sprite-camel-case-2x, )
 );
 
-/*
-These "retina group" variables are mappings for the naming and pairing of normal and retina sprites.
-
-The map variables are intended for the `retina-sprite` mixin. The list variable is for `retina-sprites`.
-*/
+// These "retina group" variables are mappings for the naming and pairing of normal and retina sprites.
+//
+// The map variables are intended for the `retina-sprite` mixin. The list variable is for `retina-sprites`.
 $sprite-dash-case-group: (
   name: 'sprite-dash-case',
   normal: $sprite-dash-case,
@@ -114,32 +110,30 @@ $sprite-camel-case-group: (
 );
 $retina-groups: ($sprite-dash-case-group, $sprite-snake-case-group, $sprite-camel-case-group, );
 
-/*
-The provided mixins are intended to be used with variables directly
-
-.icon-home {
-  @include sprite-width($icon-home);
-}
-
-.icon-email {
-  @include sprite($icon-email);
-}
-
-Example usage in HTML:
-
-`display: block` sprite:
-<div class="icon-home"></div>
-
-To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
-
-// CSS
-.icon {
-  display: inline-block;
-}
-
-// HTML
-<i class="icon icon-home"></i>
-*/
+// The provided mixins are intended to be used with variables directly
+//
+// .icon-home {
+//   @include sprite-width($icon-home);
+// }
+//
+// .icon-email {
+//   @include sprite($icon-email);
+// }
+//
+// Example usage in HTML:
+//
+// `display: block` sprite:
+// <div class="icon-home"></div>
+//
+// To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
+//
+// // CSS
+// .icon {
+//   display: inline-block;
+// }
+//
+// // HTML
+// <i class="icon icon-home"></i>
 @mixin sprite-width($sprite) {
   width: map-get($sprite, 'width');
 }
@@ -163,22 +157,20 @@ To change `display` (e.g. `display: inline-block;`), we suggest using a common C
   @include sprite-height($sprite);
 }
 
-/*
-The `retina-sprite` mixin sets up rules and a media query for a sprite/retina sprite.
-  It should be used with a "retina group" variable.
-
-The media query is from CSS Tricks: https://css-tricks.com/snippets/css/retina-display-media-query/
-
-$icon-home-group: (
-  name: 'icon-home',
-  normal: $icon-home,
-  retina: $icon-home-2x
-);
-
-.icon-home {
-  @include retina-sprite($icon-home-group);
-}
-*/
+// The `retina-sprite` mixin sets up rules and a media query for a sprite/retina sprite.
+//   It should be used with a "retina group" variable.
+//
+// The media query is from CSS Tricks: https://css-tricks.com/snippets/css/retina-display-media-query/
+//
+// $icon-home-group: (
+//   name: 'icon-home',
+//   normal: $icon-home,
+//   retina: $icon-home-2x
+// );
+//
+// .icon-home {
+//   @include retina-sprite($icon-home-group);
+// }
 @mixin sprite-background-size($sprite) {
   background-size: map-get($sprite, 'total-width') map-get($sprite, 'total-height');
 }
@@ -195,12 +187,10 @@ $icon-home-group: (
   }
 }
 
-/*
-The `sprites` mixin generates identical output to the CSS template
-  but can be overridden inside of SCSS
-
-@include sprites(map-get($spritesheet, 'sprites'));
-*/
+// The `sprites` mixin generates identical output to the CSS template
+//   but can be overridden inside of SCSS
+//
+// @include sprites(map-get($spritesheet, 'sprites'));
 @mixin sprites($sprites) {
   @each $sprite in $sprites {
     $sprite-name: map-get($sprite, 'name');
@@ -210,12 +200,10 @@ The `sprites` mixin generates identical output to the CSS template
   }
 }
 
-/*
-The `retina-sprites` mixin generates a CSS rule and media query for retina groups
-  This yields the same output as CSS retina template but can be overridden in SCSS
-
-@include retina-sprites($retina-groups);
-*/
+// The `retina-sprites` mixin generates a CSS rule and media query for retina groups
+//   This yields the same output as CSS retina template but can be overridden in SCSS
+//
+// @include retina-sprites($retina-groups);
 @mixin retina-sprites($retina-groups) {
   @each $retina-group in $retina-groups {
     $sprite-name: map-get($retina-group, 'name');

--- a/test/expected_files/scss_retina.scss
+++ b/test/expected_files/scss_retina.scss
@@ -1,16 +1,14 @@
-/*
-SCSS variables are information about icon's compiled state, stored under its original file name
-
-.icon-home {
-  width: $icon-home-width;
-}
-
-The large array-like variables contain all information about a single icon
-$icon-home: x y offset_x offset_y width height total_width total_height image_path;
-
-At the bottom of this section, we provide information about the spritesheet itself
-$spritesheet: width height image $spritesheet-sprites;
-*/
+// SCSS variables are information about icon's compiled state, stored under its original file name
+//
+// .icon-home {
+//   width: $icon-home-width;
+// }
+//
+// The large array-like variables contain all information about a single icon
+// $icon-home: x y offset_x offset_y width height total_width total_height image_path;
+//
+// At the bottom of this section, we provide information about the spritesheet itself
+// $spritesheet: width height image $spritesheet-sprites;
 $sprite-dash-case-name: 'sprite-dash-case';
 $sprite-dash-case-x: 0px;
 $sprite-dash-case-y: 0px;
@@ -88,11 +86,9 @@ $retina-spritesheet-image: 'nested/dir/spritesheet@2x.png';
 $retina-spritesheet-sprites: ($sprite-dash-case-2x, $sprite-snake-case-2x, $sprite-camel-case-2x, );
 $retina-spritesheet: (160px, 200px, 'nested/dir/spritesheet@2x.png', $retina-spritesheet-sprites, );
 
-/*
-These "retina group" variables are mappings for the naming and pairing of normal and retina sprites.
-
-The list formatted variables are intended for mixins like `retina-sprite` and `retina-sprites`.
-*/
+// These "retina group" variables are mappings for the naming and pairing of normal and retina sprites.
+//
+// The list formatted variables are intended for mixins like `retina-sprite` and `retina-sprites`.
 $sprite-dash-case-group-name: 'sprite-dash-case';
 $sprite-dash-case-group: ('sprite-dash-case', $sprite-dash-case, $sprite-dash-case-2x, );
 $sprite-snake-case-group-name: 'sprite_snake_case';
@@ -101,32 +97,30 @@ $sprite-camel-case-group-name: 'spriteCamelCase';
 $sprite-camel-case-group: ('spriteCamelCase', $sprite-camel-case, $sprite-camel-case-2x, );
 $retina-groups: ($sprite-dash-case-group, $sprite-snake-case-group, $sprite-camel-case-group, );
 
-/*
-The provided mixins are intended to be used with the array-like variables
-
-.icon-home {
-  @include sprite-width($icon-home);
-}
-
-.icon-email {
-  @include sprite($icon-email);
-}
-
-Example usage in HTML:
-
-`display: block` sprite:
-<div class="icon-home"></div>
-
-To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
-
-// CSS
-.icon {
-  display: inline-block;
-}
-
-// HTML
-<i class="icon icon-home"></i>
-*/
+// The provided mixins are intended to be used with the array-like variables
+//
+// .icon-home {
+//   @include sprite-width($icon-home);
+// }
+//
+// .icon-email {
+//   @include sprite($icon-email);
+// }
+//
+// Example usage in HTML:
+//
+// `display: block` sprite:
+// <div class="icon-home"></div>
+//
+// To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
+//
+// // CSS
+// .icon {
+//   display: inline-block;
+// }
+//
+// // HTML
+// <i class="icon icon-home"></i>
 @mixin sprite-width($sprite) {
   width: nth($sprite, 5);
 }
@@ -153,18 +147,16 @@ To change `display` (e.g. `display: inline-block;`), we suggest using a common C
   @include sprite-height($sprite);
 }
 
-/*
-The `retina-sprite` mixin sets up rules and a media query for a sprite/retina sprite.
-  It should be used with a "retina group" variable.
-
-The media query is from CSS Tricks: https://css-tricks.com/snippets/css/retina-display-media-query/
-
-$icon-home-group: ('icon-home', $icon-home, $icon-home-2x, );
-
-.icon-home {
-  @include retina-sprite($icon-home-group);
-}
-*/
+// The `retina-sprite` mixin sets up rules and a media query for a sprite/retina sprite.
+//   It should be used with a "retina group" variable.
+//
+// The media query is from CSS Tricks: https://css-tricks.com/snippets/css/retina-display-media-query/
+//
+// $icon-home-group: ('icon-home', $icon-home, $icon-home-2x, );
+//
+// .icon-home {
+//   @include retina-sprite($icon-home-group);
+// }
 @mixin sprite-background-size($sprite) {
   $sprite-total-width: nth($sprite, 7);
   $sprite-total-height: nth($sprite, 8);
@@ -183,12 +175,10 @@ $icon-home-group: ('icon-home', $icon-home, $icon-home-2x, );
   }
 }
 
-/*
-The `sprites` mixin generates identical output to the CSS template
-  but can be overridden inside of SCSS
-
-@include sprites($spritesheet-sprites);
-*/
+// The `sprites` mixin generates identical output to the CSS template
+//   but can be overridden inside of SCSS
+//
+// @include sprites($spritesheet-sprites);
 @mixin sprites($sprites) {
   @each $sprite in $sprites {
     $sprite-name: nth($sprite, 10);
@@ -198,12 +188,10 @@ The `sprites` mixin generates identical output to the CSS template
   }
 }
 
-/*
-The `retina-sprites` mixin generates a CSS rule and media query for retina groups
-  This yields the same output as CSS retina template but can be overridden in SCSS
-
-@include retina-sprites($retina-groups);
-*/
+// The `retina-sprites` mixin generates a CSS rule and media query for retina groups
+//   This yields the same output as CSS retina template but can be overridden in SCSS
+//
+// @include retina-sprites($retina-groups);
 @mixin retina-sprites($retina-groups) {
   @each $retina-group in $retina-groups {
     $sprite-name: nth($retina-group, 1);


### PR DESCRIPTION
To prevent the comments in the generated SASS/SCSS files from bleeding
through to the compiled CSS output, the comments in the templates have
been updated to inline instead of block.

Tests were updated as well, though some tests were previously failing (on Windows) and I did not address those pre-existing failures.

Related to #48 