### PR TITLE
Upgrade underscore.string to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "handlebars-layouts": "~1.1.0",
     "json-content-demux": "~0.1.2",
     "underscore": "~1.4.2",
-    "underscore.string": "~3.0.3"
+    "underscore.string": "~3.3.0"
   },
   "devDependencies": {
     "css-validator": "~0.5.0",


### PR DESCRIPTION
The warning info: https://www.npmjs.com/advisories/745/versions