### PR TITLE
Update underscore version to avoid security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "handlebars": "^4.6.0",
     "handlebars-layouts": "^3.1.4",
     "json-content-demux": "~0.1.2",
-    "underscore": "~1.4.2",
+    "underscore": "~1.13.1",
     "underscore.string": "~3.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Our project flagged a Security Vulnerability in the underscore dependency jashkenas/underscore#2915 which is hoisted via spritesheet-templates.

The current package.json uses "underscore": "~1.4.2". The fix for the underscore vulnerability is in versions 1.12.1,1.13.0-2.