### PR TITLE
Implemented CSS variables output

### DIFF
--- a/lib/spritesheet-templates.js
+++ b/lib/spritesheet-templates.js
@@ -317,6 +317,7 @@ var templatesDir = __dirname + '/templates';
 templater.addTemplate('json', require(templatesDir + '/json.template.js'));
 templater.addTemplate('json_array', require(templatesDir + '/json_array.template.js'));
 templater.addTemplate('css', require(templatesDir + '/css.template.js'));
+templater.addTemplate('css_variables', require(templatesDir + '/css_variables.template.js'));
 
 templater.addTemplate('json_texture', require(templatesDir + '/json_texture.template.js'));
 

--- a/lib/templates/css_variables.template.handlebars
+++ b/lib/templates/css_variables.template.handlebars
@@ -1,0 +1,45 @@
+{{#block "sprites-comment"}}
+/*
+CSS variables are information about icon's compiled state, stored under its original file name
+
+.icon-home {
+  width: var(--icon-home-width);
+}
+
+Icon classes can be used entirely standalone. They are named after their original file names.
+
+Example usage in HTML:
+
+`display: block` sprite:
+<div class="icon-home"></div>
+
+To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
+
+// CSS
+.icon {
+  display: inline-block;
+}
+
+// HTML
+<i class="icon icon-home"></i>
+*/
+{{/block}}
+{{#block "sprites"}}
+:root {
+{{#each sprites}}
+  --{{spritesheet_name}}-{{name}}-image: url('{{{escaped_image}}}');
+  --{{spritesheet_name}}-{{name}}-position: {{px.offset_x}} {{px.offset_y}};
+  --{{spritesheet_name}}-{{name}}-width: {{px.width}};
+  --{{spritesheet_name}}-{{name}}-height: {{px.height}};
+{{/each}}
+}
+
+{{#each sprites}}
+{{{selector}}} {
+  background-image: var(--{{spritesheet_name}}-{{name}}-image);
+  background-position: var(--{{spritesheet_name}}-{{name}}-position);
+  width: var(--{{spritesheet_name}}-{{name}}-width);
+  height: var(--{{spritesheet_name}}-{{name}}-height);
+}
+{{/each}}
+{{/block}}

--- a/lib/templates/css_variables.template.js
+++ b/lib/templates/css_variables.template.js
@@ -19,13 +19,13 @@ function cssVariablesTemplate(data) {
   var selectorFn =
     options.cssSelector ||
     function defaultCssClass(sprite) {
-      return ".icon-" + sprite.name;
+      return "." + sprite.spritesheet_name + "-" + sprite.name;
     };
 
   // Add class to each of the options
   sprites.forEach(function saveClass(sprite) {
-    sprite.selector = selectorFn(sprite);
     sprite.spritesheet_name = data.spritesheet_name;
+    sprite.selector = selectorFn(sprite);
   });
 
   // Render and return CSS

--- a/lib/templates/css_variables.template.js
+++ b/lib/templates/css_variables.template.js
@@ -1,0 +1,37 @@
+// Load in local modules
+var fs = require("fs");
+var handlebars = require("handlebars");
+var tmpl = fs.readFileSync(
+  __dirname + "/css_variables.template.handlebars",
+  "utf8",
+);
+
+// Register the CSS as a partial for extension
+handlebars.registerPartial("css_variables", tmpl);
+
+// Define our css template fn ({sprites, options}) -> css
+function cssVariablesTemplate(data) {
+  // Localize parameters
+  var sprites = data.sprites;
+  var options = data.options;
+
+  // Fallback class naming function
+  var selectorFn =
+    options.cssSelector ||
+    function defaultCssClass(sprite) {
+      return ".icon-" + sprite.name;
+    };
+
+  // Add class to each of the options
+  sprites.forEach(function saveClass(sprite) {
+    sprite.selector = selectorFn(sprite);
+    sprite.spritesheet_name = data.spritesheet_name;
+  });
+
+  // Render and return CSS
+  var css = handlebars.compile(tmpl)(data);
+  return css;
+}
+
+// Export our CSS template
+module.exports = cssVariablesTemplate;


### PR DESCRIPTION
# What

This PR adds native CSS variables support.

It works like this:
It writes a `:root` section in the CSS file that contains the variable declarations. Each variable name is prefixed with the name of the spritesheet, in order to avoid naming collisions in case of multiple spritesheets being used in the same project.

After the `:root` section, there is 1 section per selector, with a customizable `cssSelector` function that works exactly like the `css` template. Inside the selector, the CSS uses the previously declared variables.


# Why

I implemented this because I needed to implement multiple backgrounds for a single button, and each background was defined in the spritesheet. I could not give the button 2 classes, because each class would override each other.

With variables I could manually implement a third class, and reference the background positions of the images I needed.

# How

This is mostly a copy/paste of the standard CSS template with only the minor tweaks required for implementing variables and adding the spritesheet name to the sprites.